### PR TITLE
🚨🚨🚨 Treat all media types except video as image

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -179,6 +179,9 @@ android {
             isDebuggable = false
             isProfileable = false
             isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            )
         }
     }
     packaging.resources {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-dontobfuscate

--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
@@ -731,7 +731,7 @@ fun PostImage(
                 showMediaDialog = mediaAttachment
             })
         }) {
-            if (mediaAttachment.type == "image") {
+            if (mediaAttachment.type != "video") {
                 ImageWrapper(
                     mediaAttachment,
                     { zoomState.setContentSize(it.painter.intrinsicSize) },
@@ -848,7 +848,7 @@ fun MediaDialog(
             contentAlignment = Alignment.Center
         ) {
             Box(modifier = Modifier.zIndex(2f).zoomable(zoomState).clickable { }) {
-                if (mediaAttachment.type == "image") {
+                if (mediaAttachment.type != "video") {
                     ImageWrapper(
                         mediaAttachment,
                         { zoomState.setContentSize(it.painter.intrinsicSize) },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "2.1.20"
+kotlin = "2.1.21"
 ksp = "2.1.20-2.0.1"
-agp = "8.9.2"
+agp = "8.9.3"
 
 #https://github.com/JetBrains/compose-multiplatform/releases
 composeMultiplatform = "1.8.0"
@@ -10,7 +10,7 @@ navigationMultiplatform = "2.9.0-beta01"
 
 #JetBrains
 kotlinx-coroutines = "1.10.2"
-kotlinxCollectionsImmutable = "0.3.8"
+kotlinxCollectionsImmutable = "0.4.0"
 kotlinxSerializationJson = "1.8.1"
 ktor = "3.1.3"
 kotlinx-datetime = "0.6.2"
@@ -18,15 +18,15 @@ kotlinx-datetime = "0.6.2"
 #multiplatform
 ksoup = "0.2.3"
 kermit = "2.0.5"
-ktorfit = "2.5.1"
+ktorfit = "2.5.2"
 kotlinInject = "0.8.0"
 androidx-annotation = "1.9.1"
-coil = "3.1.0"
-datastorePreferences = "1.1.5"
+coil = "3.2.0"
+datastorePreferences = "1.1.6"
 multiplatformSettings = "1.3.0"
-filekitCompose = "0.10.0-beta03"
-krop = "0.2.0-beta01"
-composemediaplayer = "0.7.2"
+filekitCompose = "0.10.0-beta04"
+krop = "0.2.0"
+composemediaplayer = "0.7.4"
 
 #android
 accompanistSystemuicontroller = "0.36.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.21"
-ksp = "2.1.20-2.0.1"
-agp = "8.9.3"
+ksp = "2.1.21-2.0.1"
+agp = "8.10.0"
 
 #https://github.com/JetBrains/compose-multiplatform/releases
 composeMultiplatform = "1.8.0"


### PR DESCRIPTION
This commit updates the `PostComposable` to treat all media types other than "video" as "image". This ensures consistent handling of various media types and simplifies the logic for displaying and interacting with media attachments.


at the moment the app is almost broken!
there is a lot of `mediaAttachment.type == "document"`!


https://github.com/user-attachments/assets/9651f915-2506-4319-b5ac-653a29d39c31

