### PR TITLE
Navigation3 migration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.4.10"
 ksp = "2.3.6"
-agp = "9.1.1"
+agp = "9.3.2"
 
 #https://github.com/JetBrains/compose-multiplatform/releases
 composeMultiplatform = "1.12.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.4.10"
 ksp = "2.3.6"
-agp = "9.3.2"
+agp = "9.1.1"
 
 #https://github.com/JetBrains/compose-multiplatform/releases
 composeMultiplatform = "1.12.0"
@@ -9,6 +9,8 @@ lifecycleMultiplatform = "2.11.0"
 material3 = "1.12.0-alpha03"
 materialVersion = "1.12.0"
 navigationMultiplatform = "2.10.0-alpha02"
+navigation3 = "1.2.0-alpha02"
+navigation3Browser = "1.1.0"
 composeNavigationEvent = "1.1.0"
 
 #JetBrains
@@ -24,7 +26,7 @@ kermit = "2.1.0"
 ktorfit = "2.7.5"
 kotlinInject = "0.9.0"
 androidx-annotation = "1.10.0"
-coil = "3.6.0"
+coil = "3.6.1"
 datastorePreferences = "1.3.0-alpha10"
 filekitCompose = "0.15.0"
 krop = "0.2.0"
@@ -64,6 +66,9 @@ androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:life
 androidx-lifecycle-viewmodel-savedstate = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "lifecycleMultiplatform" }
 
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationMultiplatform" }
+jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleMultiplatform" }
+navigation3-browser = { module = "com.github.terrakok:navigation3-browser", version.ref = "navigation3Browser" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastorePreferences" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ composeMultiplatform = "1.12.0"
 lifecycleMultiplatform = "2.11.0"
 material3 = "1.12.0-alpha03"
 materialVersion = "1.12.0"
-navigationMultiplatform = "2.10.0-alpha02"
 navigation3 = "1.2.0-alpha02"
 navigation3Browser = "1.1.0"
 composeNavigationEvent = "1.1.0"
@@ -65,7 +64,6 @@ androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycl
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleMultiplatform" }
 androidx-lifecycle-viewmodel-savedstate = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "lifecycleMultiplatform" }
 
-androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationMultiplatform" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleMultiplatform" }
 navigation3-browser = { module = "com.github.terrakok:navigation3-browser", version.ref = "navigation3Browser" }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,11 +7,6 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
-
 ws@8.20.1:
   version "8.20.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -114,7 +114,6 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodel.savedstate)
 
             //navigation
-            implementation(libs.androidx.navigation.compose)
             implementation(libs.jetbrains.navigation3.ui)
             implementation(libs.jetbrains.lifecycle.viewmodel.navigation3)
 

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -115,6 +115,8 @@ kotlin {
 
             //navigation
             implementation(libs.androidx.navigation.compose)
+            implementation(libs.jetbrains.navigation3.ui)
+            implementation(libs.jetbrains.lifecycle.viewmodel.navigation3)
 
             //annotation
             implementation(libs.androidx.annotation)
@@ -132,6 +134,10 @@ kotlin {
 
             //video player
             implementation(libs.composemediaplayer)
+        }
+
+        webMain.dependencies {
+            implementation(libs.navigation3.browser)
         }
 
         androidMain.dependencies {

--- a/sharedUI/src/androidMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.android.kt
+++ b/sharedUI/src/androidMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.android.kt
@@ -8,6 +8,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.FileProvider
 import co.touchlab.kermit.Logger
 import com.daniebeler.pfpixelix.MyApplication
+import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.KmpUri
@@ -35,6 +36,10 @@ actual class Platform actual constructor(
 
         return contentUri
     }
+
+    actual fun prepareAuthBrowser(host: String, backendType: BackendType): Boolean = true
+
+    actual suspend fun consumePreparedAuthData(): PreparedAuthData? = null
 
     actual fun openUrl(url: String) {
         val activity = MyApplication.currentActivity?.get()
@@ -68,7 +73,7 @@ actual class Platform actual constructor(
 
     actual fun dismissBrowser() {}
 
-        actual fun getAppVersion(): String {
+    actual fun getAppVersion(): String {
         return try {
             context.packageManager.getPackageInfo(context.packageName, 0).versionName
         } catch (e: Throwable) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation3.scene.DialogSceneStrategy
+import androidx.navigation3.scene.SinglePaneSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import co.touchlab.kermit.Logger
@@ -231,6 +233,10 @@ fun App(
                                         )
                                     ),
                                     onBack = navController::popBackStack,
+                                    sceneStrategies = listOf(
+                                        remember { DialogSceneStrategy() },
+                                        remember { SinglePaneSceneStrategy() },
+                                    ),
                                     modifier = Modifier.fillMaxSize(),
                                 )
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
@@ -102,7 +102,6 @@ val LocalSnackbarPresenter = compositionLocalOf<(String) -> Unit> {
 @Composable
 fun App(
     appComponent: AppComponent,
-    browserNavigation: @Composable (Destination) -> Unit = {},
     exitApp: () -> Unit
 ) {
     val uriHandler = LocalUriHandler.current
@@ -154,6 +153,10 @@ fun App(
                 }
             }
             if (activeUser == "unknown") return@PixelixTheme
+
+            // navigation3-browser permits a single binding for the lifetime of the page.
+            // Keep it outside the session key so login/logout does not dispose the active binding.
+            BrowserIntegration()
 
             key(activeUser) {
                 val scope = rememberCoroutineScope()
@@ -223,7 +226,6 @@ fun App(
                             modifier = Modifier.nestedScroll(scrollBehaviorBottom)
                         ) { paddingValues ->
                             Box(Modifier.fillMaxSize().padding(paddingValues)) {
-                                browserNavigation(navigationState.currentDestination)
                                 NavDisplay(
                                     entries = navigationState.decoratedEntries(
                                         appEntryProvider(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
@@ -56,12 +56,8 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.navigation.NavController
-import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.ui.NavDisplay
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.AppComponent
@@ -71,7 +67,8 @@ import com.daniebeler.pfpixelix.ui.composables.settings.preferences.prefs.Prefer
 import com.daniebeler.pfpixelix.ui.composables.widgets.ReverseModalNavigationDrawer
 import com.daniebeler.pfpixelix.ui.events.GlobalNavigationEvent
 import com.daniebeler.pfpixelix.ui.navigation.Destination
-import com.daniebeler.pfpixelix.ui.navigation.appGraph
+import com.daniebeler.pfpixelix.ui.navigation.appEntryProvider
+import com.daniebeler.pfpixelix.ui.navigation.rememberAppNavigationState
 import com.daniebeler.pfpixelix.ui.theme.PixelixTheme
 import com.daniebeler.pfpixelix.utils.end
 import kotlinx.coroutines.delay
@@ -103,7 +100,7 @@ val LocalSnackbarPresenter = compositionLocalOf<(String) -> Unit> {
 @Composable
 fun App(
     appComponent: AppComponent,
-    onNavHostReady: suspend (NavController) -> Unit = {},
+    onNavHostReady: suspend (AppNavigator) -> Unit = {},
     exitApp: () -> Unit
 ) {
     val uriHandler = LocalUriHandler.current
@@ -161,7 +158,12 @@ fun App(
                 val drawerState = rememberDrawerState(DrawerValue.Closed)
                 val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
                 var showAccountSwitchBottomSheet by remember { mutableStateOf(false) }
-                val navController = rememberNavController()
+                val startDestination =
+                    if (activeUser == null) Destination.FirstLogin else Destination.HomeTabFeeds
+                val navigationState = rememberAppNavigationState(startDestination)
+                val navController = remember(navigationState, exitApp) {
+                    AppNavigator(navigationState, exitApp)
+                }
 
                 val snackbarHostState = remember { SnackbarHostState() }
                 val snackBarPresenter: (String) -> Unit = { msg ->
@@ -176,28 +178,24 @@ fun App(
                 // Activity/Fragment because you didn't actually destroy them properly,
                 // you just dropped any access to them
                 LaunchedEffect(activeUser) {
-                    navController.clearBackStack<Destination.HomeTabFeeds>()
-                    navController.clearBackStack<Destination.HomeTabSearch>()
-                    navController.clearBackStack<Destination.HomeTabNewPost>()
-                    navController.clearBackStack<Destination.HomeTabNotifications>()
-                    navController.clearBackStack<Destination.HomeTabOwnProfile>()
+                    navController.clearBackStack(Destination.HomeTabFeeds)
+                    navController.clearBackStack(Destination.HomeTabSearch)
+                    navController.clearBackStack(Destination.HomeTabNewPost)
+                    navController.clearBackStack(Destination.HomeTabNotifications)
+                    navController.clearBackStack(Destination.HomeTabOwnProfile)
                 }
 
                 LaunchedEffect(appComponent.globalNavigator) {
                     appComponent.globalNavigator.navigationEvents.collect { event ->
                         when (event) {
                             is GlobalNavigationEvent.NavigateToLogin -> {
-                                navController.navigate(Destination.FirstLogin) {
-                                    popUpTo(navController.graph.startDestinationId) {
-                                        inclusive = true
-                                    }
-                                }
+                                navController.clearAndNavigate(Destination.FirstLogin)
                             }
                         }
                     }
                 }
 
-                // Bridges the NavController to the host platform once the graph is set up.
+                // Bridges the AppNavigator to the host platform once the graph is set up.
                 // On web this binds browser Back/Forward and the address bar to navigation;
                 // other platforms pass the default no-op.
                 LaunchedEffect(navController) {
@@ -230,33 +228,32 @@ fun App(
                             modifier = Modifier.nestedScroll(scrollBehaviorBottom)
                         ) { paddingValues ->
                             Box(Modifier.fillMaxSize().padding(paddingValues)) {
-                                val startDestination =
-                                    if (activeUser == null) Destination.FirstLogin
-                                    else Destination.HomeTabFeeds
-                                NavHost(
-                                    modifier = Modifier.fillMaxSize(),
-                                    navController = navController,
-                                    startDestination = startDestination,
-                                    builder = {
-                                        appGraph(
+                                NavDisplay(
+                                    entries = navigationState.decoratedEntries(
+                                        appEntryProvider(
                                             navController,
                                             { scope.launch { drawerState.open() } },
-                                            exitApp
+                                            exitApp,
                                         )
-                                    })
+                                    ),
+                                    onBack = navController::popBackStack,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
 
-                                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                                val currentDestination = navBackStackEntry?.destination
-
-                                val showBottomBar =
-                                    currentDestination?.hasRoute<Destination.OwnProfile>() == true || currentDestination?.hasRoute<Destination.Feeds>() == true || currentDestination?.hasRoute<Destination.Search>() == true || currentDestination?.hasRoute<Destination.Notifications>() == true
+                                val currentDestination = navigationState.currentDestination
+                                val showBottomBar = currentDestination == Destination.Feeds ||
+                                    currentDestination is Destination.Search ||
+                                    currentDestination == Destination.Notifications ||
+                                    currentDestination == Destination.OwnProfile ||
+                                    currentDestination in HomeTab.entries.map { it.destination }
 
                                 if (showBottomBar) {
                                     Box(
                                         modifier = Modifier.align(Alignment.BottomCenter)
                                     ) {
                                         BottomBarFloating(
-                                            navController, scrollBehaviorBottom
+                                            navController, navigationState.currentDestination,
+                                            navigationState.currentTopLevel, scrollBehaviorBottom
                                         )
 
                                     }
@@ -336,7 +333,9 @@ private enum class HomeTab(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun BottomBarFloating(
-    navController: NavController,
+    navController: AppNavigator,
+    currentDestination: Destination,
+    currentTopLevel: Destination,
     scrollBehavior: FloatingToolbarScrollBehavior
 ) {
     var avatar by remember { mutableStateOf<String?>(null) }
@@ -349,14 +348,11 @@ private fun BottomBarFloating(
         }
     }
 
-    val navBackStackEntry = navController.currentBackStackEntryAsState().value
-    val currentDestination = navBackStackEntry?.destination ?: return
-
     val systemNavigationBarHeight =
         WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     HorizontalFloatingToolbar(
         expanded = true,
-        scrollBehavior = if (currentDestination.hasRoute<Destination.NewPost>()) null else scrollBehavior,
+        scrollBehavior = if (currentDestination is Destination.NewPost) null else scrollBehavior,
         modifier = Modifier.padding(bottom = systemNavigationBarHeight + 4.dp),
         colors = FloatingToolbarColors(
             toolbarContentColor = MaterialTheme.colorScheme.onSurface,
@@ -366,10 +362,7 @@ private fun BottomBarFloating(
         )
     ) {
         HomeTab.entries.forEachIndexed { _, tab ->
-            val isSelected =
-                currentDestination.hasRoute(tab.destination::class) || currentDestination.parent?.hasRoute(
-                    tab.destination::class
-                ) == true
+            val isSelected = currentTopLevel == tab.destination
 
 
             val containerColor =
@@ -391,9 +384,9 @@ private fun BottomBarFloating(
                                     }
                                 }
                             } else {
-                                if (currentDestination.hasRoute<Destination.Search>()) {
+                                if (currentDestination is Destination.Search || currentTopLevel == Destination.HomeTabSearch) {
                                     appComponent.searchFieldFocus.focus()
-                                } else if (currentDestination.hasRoute<Destination.Feeds>()) {
+                                } else if (currentDestination == Destination.Feeds || currentTopLevel == Destination.HomeTabFeeds) {
                                     appComponent.backToTopTrigger.scrollToTop()
                                 }
                             }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/App.kt
@@ -100,7 +100,7 @@ val LocalSnackbarPresenter = compositionLocalOf<(String) -> Unit> {
 @Composable
 fun App(
     appComponent: AppComponent,
-    onNavHostReady: suspend (AppNavigator) -> Unit = {},
+    browserNavigation: @Composable (Destination) -> Unit = {},
     exitApp: () -> Unit
 ) {
     val uriHandler = LocalUriHandler.current
@@ -195,13 +195,6 @@ fun App(
                     }
                 }
 
-                // Bridges the AppNavigator to the host platform once the graph is set up.
-                // On web this binds browser Back/Forward and the address bar to navigation;
-                // other platforms pass the default no-op.
-                LaunchedEffect(navController) {
-                    onNavHostReady(navController)
-                }
-
                 CompositionLocalProvider(
                     LocalSnackbarPresenter provides snackBarPresenter
                 ) {
@@ -228,6 +221,7 @@ fun App(
                             modifier = Modifier.nestedScroll(scrollBehaviorBottom)
                         ) { paddingValues ->
                             Box(Modifier.fillMaxSize().padding(paddingValues)) {
+                                browserNavigation(navigationState.currentDestination)
                                 NavDisplay(
                                     entries = navigationState.decoratedEntries(
                                         appEntryProvider(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/BrowserIntegration.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/BrowserIntegration.kt
@@ -1,0 +1,6 @@
+package com.daniebeler.pfpixelix
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun BrowserIntegration()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/pixelfed/PixelfedAuthService.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/pixelfed/PixelfedAuthService.kt
@@ -11,6 +11,7 @@ import com.daniebeler.pfpixelix.domain.service.general.AuthService.Companion.gra
 import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.general.Session
 import com.daniebeler.pfpixelix.domain.service.platform.Platform
+import com.daniebeler.pfpixelix.domain.service.platform.PreparedAuthData
 import com.daniebeler.pfpixelix.domain.service.platform.redirectUrl
 import com.daniebeler.pfpixelix.domain.service.search.SavedSearchesService
 import com.daniebeler.pfpixelix.ui.events.SystemUrlHandler
@@ -36,18 +37,24 @@ class PixelfedAuthService(
     override suspend fun auth(host: String) {
         val serverUrl = getServerUrl(host)
         val api = createPixelfedAuthApi(serverUrl, json)
-        val authData = api.getAuthData(clientName, platform.redirectUrl)
+        val preparedAuthData = platform.consumePreparedAuthData()
+        val client = preparedAuthData ?: api.getAuthData(
+            clientName,
+            platform.redirectUrl
+        ).let { PreparedAuthData(it.clientId, it.clientSecret) }
+        val clientId = client.clientId
+        val clientSecret = requireNotNull(client.clientSecret) { "OAuth registration returned no client_secret" }
 
         val authUrl = URLBuilder("${serverUrl}oauth/authorize").apply {
             parameters.apply {
                 append("response_type", "code")
                 append("redirect_uri", platform.redirectUrl)
-                append("client_id", authData.clientId)
+                append("client_id", clientId)
             }
         }.build()
 
         urlHandler.isAuthInProgress = true
-        platform.openUrl(authUrl.toString())
+        if (preparedAuthData == null) platform.openUrl(authUrl.toString())
         val redirectString = urlHandler.redirects.first()
         platform.dismissBrowser()
 
@@ -58,8 +65,8 @@ class PixelfedAuthService(
         val code = redirect.parameters["code"] ?: error("Redirect doesn't have a code")
 
         val token = api.getToken(
-            authData.clientId,
-            authData.clientSecret,
+            clientId,
+            clientSecret,
             code,
             platform.redirectUrl,
             grantType
@@ -75,8 +82,8 @@ class PixelfedAuthService(
             serverUrl = serverUrl.toString(),
             token = token.accessToken,
             refreshToken = token.refreshToken,
-            clientId = authData.clientId,
-            clientSecret = authData.clientSecret,
+            clientId = clientId,
+            clientSecret = clientSecret,
             createdAt = token.createdAt,
             backendType = BackendType.PIXELFED
         )

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.kt
@@ -1,5 +1,6 @@
 package com.daniebeler.pfpixelix.domain.service.platform
 
+import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.KmpUri
@@ -12,11 +13,22 @@ expect class Platform(
     prefs: UserPreferences
 ) {
     fun toSafeUri(platformFile: PlatformFile): KmpUri
+
+    /** Starts browser-side OAuth during the user gesture. Non-web platforms do nothing. */
+    fun prepareAuthBrowser(host: String, backendType: BackendType): Boolean
+
+    /** Returns data prepared by the web launcher, or null when OAuth must start in the app. */
+    suspend fun consumePreparedAuthData(): PreparedAuthData?
     fun openUrl(url: String)
     fun dismissBrowser()
     fun shareText(text: String)
     fun getAppVersion(): String
     fun pinWidget()
 }
+
+data class PreparedAuthData(
+    val clientId: String,
+    val clientSecret: String?
+)
 
 internal expect val Platform.redirectUrl: String

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/vernissage/VernissageAuthService.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/vernissage/VernissageAuthService.kt
@@ -39,7 +39,11 @@ class VernissageAuthService(
         val serverUrl = getServerUrl(host)
         val api = createVernissageAuthApi(serverUrl, json)
 
-        val authData = api.getAuthData("Pixelix", listOf("dev.ghostbyte.pixelix://callback"))
+        val preparedAuthData = platform.consumePreparedAuthData()
+        val clientId = preparedAuthData?.clientId ?: api.getAuthData(
+            "Pixelix",
+            listOf(platform.redirectUrl)
+        ).clientId
 
         val state = Random.nextInt(100000, 999999).toString()
         val nonce = Random.nextInt(100000, 999999).toString()
@@ -51,7 +55,7 @@ class VernissageAuthService(
 
             parameters.apply {
                 append("response_type", "code")
-                append("client_id", authData.clientId)
+                append("client_id", clientId)
                 append("redirect_uri", platform.redirectUrl)
                 append("scope", scope)
                 append("state", state)
@@ -60,7 +64,7 @@ class VernissageAuthService(
         }.build()
 
         urlHandler.isAuthInProgress = true
-        platform.openUrl(authUrl.toString())
+        if (preparedAuthData == null) platform.openUrl(authUrl.toString())
         val redirectString = urlHandler.redirects.first()
         platform.dismissBrowser()
 
@@ -69,8 +73,6 @@ class VernissageAuthService(
         }
         val redirect = Url(redirectString)
         val code = redirect.parameters["code"] ?: error("Redirect doesn't have a code")
-
-        val clientId = authData.clientId
 
         val tokenResponse = api.getToken(
             clientId = clientId,
@@ -101,7 +103,7 @@ class VernissageAuthService(
             serverUrl = serverUrl.toString(),
             token = tokenResponse.accessToken + "test",
             refreshToken = tokenResponse.refreshToken,
-            clientId = authData.clientId,
+            clientId = clientId,
             clientSecret = "authData.clientSecret",
             createdAt = "tokenResponse.createdAt",
             backendType = BackendType.VERNISSAGE

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/HomeComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/HomeComposable.kt
@@ -40,8 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.LocalAppComponent
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.contribute.ContributeBottomSheet
@@ -68,7 +67,7 @@ import pixelix.app.generated.resources.settings
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeComposable(
-    navController: NavController,
+    navController: AppNavigator,
     openPreferencesDrawer: () -> Unit,
     viewModel: HomeViewModel = injectViewModel("homeViewModel") { homeViewModel },
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/collection/CollectionComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/collection/CollectionComposable.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.profile.ViewEnum
 import com.daniebeler.pfpixelix.ui.composables.widgets.ButtonRowElement
@@ -64,7 +64,7 @@ import pixelix.app.generated.resources.share_this_collection
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CollectionComposable(
-    navController: NavController,
+    navController: AppNavigator,
     collectionId: String,
     viewModel: CollectionViewModel = injectViewModel(key = "collection-viewmodel-key") { collectionViewModel }
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/custom_account/CustomAccount.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/custom_account/CustomAccount.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Account
@@ -47,7 +47,7 @@ import pixelix.app.generated.resources.trash
 fun AccountListItem(
     account: Account,
     relationship: Relationship?,
-    navController: NavController,
+    navController: AppNavigator,
     index: Int,
     count: Int,
     showFollowers: Boolean = true,
@@ -150,7 +150,7 @@ fun AccountListItem(
 fun CustomAccount(
     account: Account,
     relationship: Relationship?,
-    navController: NavController,
+    navController: AppNavigator,
     showFollowers: Boolean = true,
     onClick: () -> Unit = {},
     removeSavedSearch: (() -> Unit)? = null,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/chat/ChatComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/chat/ChatComposable.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.states.EndOfListComposable
@@ -74,7 +74,7 @@ import pixelix.app.generated.resources.send
 
 @Composable
 fun ChatComposable(
-    navController: NavController,
+    navController: AppNavigator,
     accountId: String,
     viewModel: ChatViewModel = injectViewModel(key = "chat$accountId") { chatViewModel }
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/chat/ChatElementComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/chat/ChatElementComposable.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Message
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
@@ -37,7 +37,7 @@ import pixelix.app.generated.resources.trash
 
 @Composable
 fun ConversationElementComposable(
-    message: Message, deleteMessage: () -> Unit, navController: NavController
+    message: Message, deleteMessage: () -> Unit, navController: AppNavigator
 ) {
     var arrangement = Arrangement.Start
     var alignment = Alignment.Start

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationElementComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationElementComposable.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.Conversation
 import com.daniebeler.pfpixelix.ui.navigation.Destination
@@ -27,7 +27,7 @@ import pixelix.app.generated.resources.Res
 import pixelix.app.generated.resources.default_avatar
 
 @Composable
-fun ConversationElementComposable(conversation: Conversation, navController: NavController) {
+fun ConversationElementComposable(conversation: Conversation, navController: AppNavigator) {
 
     Row(
         Modifier

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationsComposable.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.widgets.InfiniteStaggeredGridHandler
 import com.daniebeler.pfpixelix.ui.composables.SheetItem
@@ -71,7 +71,7 @@ import pixelix.app.generated.resources.you_don_t_have_any_notifications
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConversationsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: ConversationsViewModel = injectViewModel(key = "conversations-viewmodel-key") { conversationsViewModel }
 ) {
 
@@ -196,7 +196,7 @@ fun ConversationsComposable(
 
 @Composable
 private fun CreateNewConversation(
-    close: () -> Unit, viewModel: ConversationsViewModel, navController: NavController
+    close: () -> Unit, viewModel: ConversationsViewModel, navController: AppNavigator
 ) {
 
     AlertDialog(title = {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/edit_profile/EditProfileComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/edit_profile/EditProfileComposable.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
@@ -120,7 +120,7 @@ import pixelix.app.generated.resources.website
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditProfileComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: EditProfileViewModel = injectViewModel(key = "edit-profile-viewmodel-key") { editProfileViewModel }
 ) {
     val suggestionsState by viewModel.hashtagMentionsSuggestionsManager.suggestionsState.collectAsStateWithLifecycle()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/ExploreComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/ExploreComposable.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.LocalAppComponent
@@ -89,7 +89,7 @@ import pixelix.app.generated.resources.trash
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExploreComposable(
-    navController: NavController,
+    navController: AppNavigator,
     initialPage: Int = 0,
     viewModel: ExploreViewModel = injectViewModel(key = "search-viewmodel-key") { exploreViewModel }
 ) {
@@ -244,7 +244,7 @@ private fun SearchResultComposable(
     searchState: SearchState,
     saveAccount: (String, Account) -> Unit,
     saveHashtag: (String) -> Unit,
-    navController: NavController
+    navController: AppNavigator
 ) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 2 })
     val scope = rememberCoroutineScope()
@@ -316,7 +316,7 @@ private fun SearchResultComposable(
 @Composable
 private fun PastSearchItem(
     item: SavedSearchItem,
-    navController: NavController,
+    navController: AppNavigator,
     setSearchText: (text: String) -> Unit,
     deleteSavedSearch: () -> Unit
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/TrendingComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/TrendingComposable.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.ui.composables.explore.ExploreViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.cameras.CamerasComposable
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.categories.CategoriesComposable
@@ -53,7 +53,7 @@ enum class TrendingRange {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TrendingComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: ExploreViewModel,
     initialPage: Int,
     isSwipeEnabled: Boolean

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/cameras/CamerasComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/cameras/CamerasComposable.kt
@@ -3,7 +3,7 @@ package com.daniebeler.pfpixelix.ui.composables.explore.trending.cameras
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.PagePaginatedListScreen
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.trending_hashtags.ExploreGridElement
@@ -18,7 +18,7 @@ import pixelix.app.generated.resources.posts
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CamerasComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: CamerasViewModel = injectViewModel(key = "cameras-key") { camerasViewModel }
 ) {
     PagePaginatedListScreen(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/categories/CategoriesComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/categories/CategoriesComposable.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.TrendingRange
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.trending_hashtags.ExploreGridElement
@@ -37,7 +37,7 @@ import pixelix.app.generated.resources.no_trending_hashtags
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CategoriesComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: CategoriesViewModel = injectViewModel(key = "categories-key") { categoriesViewModel }
 ) {
     val lazyListState = rememberLazyListState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/editors_choice_accounts/EditorsChoiceAccountsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/editors_choice_accounts/EditorsChoiceAccountsComposable.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.trending_accounts.TrendingAccountElement
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -33,7 +33,7 @@ import pixelix.app.generated.resources.no_trending_profiles
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun EditorsChoiceAccountsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: EditorsChoiceAccountsViewModel = injectViewModel(key = "editors-choice-accounts-key") { editorsChoiceAccountsViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/editors_choice_posts/EditorsChoicePostsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/editors_choice_posts/EditorsChoicePostsComposable.kt
@@ -6,7 +6,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.TimelineHelpCard
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.ParametricTimelineViewModel
@@ -19,7 +19,7 @@ import pixelix.app.generated.resources.editors_choice_posts_explained
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun EditorsChoicePostsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "editors-choice-posts") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.EDITORS_CHOICE_POSTS) }
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/films/FilmsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/films/FilmsComposable.kt
@@ -1,7 +1,7 @@
 package com.daniebeler.pfpixelix.ui.composables.explore.trending.films
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.PagePaginatedListScreen
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.trending_hashtags.ExploreGridElement
@@ -15,7 +15,7 @@ import pixelix.app.generated.resources.posts
 
 @Composable
 fun FilmsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: FilmsViewModel = injectViewModel(key = "films-key") { filmsViewModel }
 ) {
     PagePaginatedListScreen(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/lenses/LensesComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/lenses/LensesComposable.kt
@@ -3,7 +3,7 @@ package com.daniebeler.pfpixelix.ui.composables.explore.trending.lenses
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.PagePaginatedListScreen
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.trending_hashtags.ExploreGridElement
@@ -19,7 +19,7 @@ import pixelix.app.generated.resources.posts
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LensesComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: LensesViewModel = injectViewModel(key = "lenses-key") { lensesViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_accounts/TrendingAccountElement.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_accounts/TrendingAccountElement.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.ui.composables.widgets.CustomPost
@@ -29,7 +29,7 @@ import com.daniebeler.pfpixelix.ui.navigation.Destination
 @Composable
 fun TrendingAccountElement(
     account: Account,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: TrendingAccountElementViewModel = injectViewModel(key = account.id) { trendingAccountElementViewModel }
 ) {
     LaunchedEffect(account) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_accounts/TrendingAccountsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_accounts/TrendingAccountsComposable.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.TrendingRange
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -33,7 +33,7 @@ import pixelix.app.generated.resources.no_trending_profiles
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TrendingAccountsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: TrendingAccountsViewModel = injectViewModel(key = "trending-accounts-key") { trendingAccountsViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_hashtags/ExploreElement.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_hashtags/ExploreElement.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.PaginatedResponse
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -45,7 +45,7 @@ fun ExploreGridElement(
     subtitle: String? = null,
     onClick: () -> Unit,
     fetcher: (String) -> Flow<Resource<PaginatedResponse<Post>>>,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: TrendingHashtagElementViewModel = injectViewModel(key = "explore_$keyId") { trendingHashtagElementViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_hashtags/TrendingHashtagsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_hashtags/TrendingHashtagsComposable.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.TrendingRange
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -37,7 +37,7 @@ import pixelix.app.generated.resources.posts
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TrendingHashtagsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: TrendingHashtagsViewModel = injectViewModel(key = "trending-hashtags-key") { trendingHashtagsViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_posts/TrendingPostsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/trending_posts/TrendingPostsComposable.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.explore.trending.TrendingRange
 import com.daniebeler.pfpixelix.ui.composables.states.ErrorComposableDialog
@@ -22,7 +22,7 @@ import pixelix.app.generated.resources.datetime
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun TrendingPostsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: TrendingPostsViewModel = injectViewModel(key = "trending-posts") { trendingPostsViewModel }
 ) {
     val calendarIcon = vectorResource(Res.drawable.datetime)

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowersComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowersComposable.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.custom_account.AccountListItem
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -27,7 +27,7 @@ import pixelix.app.generated.resources.user_group
 
 @Composable
 fun FollowersComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: FollowersViewModel = injectViewModel(key = "followers-viewmodel-key") { followersViewModel }
 ) {
     val staggeredGridState = rememberLazyStaggeredGridState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowersMainComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowersMainComposable.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.pluralStringResource
@@ -49,7 +49,7 @@ import pixelix.app.generated.resources.following
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FollowersMainComposable(
-    navController: NavController,
+    navController: AppNavigator,
     accountId: String,
     username: String,
     isFollowers: Boolean,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowingComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/followers/FollowingComposable.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.custom_account.AccountListItem
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -29,7 +29,7 @@ import pixelix.app.generated.resources.user_group
 
 @Composable
 fun FollowingComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: FollowersViewModel = injectViewModel(key = "followers-viewmodel-key") { followersViewModel }
 ) {
     val staggeredGridState = rememberLazyStaggeredGridState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/hashtagMentionText/TextWithClickableHashtagsAndMentionsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/hashtagMentionText/TextWithClickableHashtagsAndMentionsComposable.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Account
@@ -51,7 +51,7 @@ fun HashtagsMentionsTextView(
     text: String,
     modifier: Modifier = Modifier,
     mentions: List<Account>?,
-    navController: NavController,
+    navController: AppNavigator,
     openUrl: (url: String) -> Unit,
     textSize: TextUnit? = null,
     maximumLines: Int = Int.MAX_VALUE,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/mention/MentionComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/mention/MentionComposable.kt
@@ -34,8 +34,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Post
 import com.daniebeler.pfpixelix.ui.composables.post.PostComposable
@@ -55,7 +54,7 @@ import pixelix.app.generated.resources.post
 @Composable
 fun MentionComposable(
     mentionId: String,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: MentionViewModel = injectViewModel(key = "mention$mentionId") { mentionViewModel }
 ) {
     val lazyListState = rememberLazyListState()
@@ -139,7 +138,7 @@ fun MentionComposable(
 }
 
 @Composable
-private fun SubPosts(posts: List<Post>, navController: NavController) {
+private fun SubPosts(posts: List<Post>, navController: AppNavigator) {
     Column(Modifier.padding(start = 32.dp), verticalArrangement = Arrangement.spacedBy(32.dp)) {
         posts.forEach { ancestor ->
             CustomLayoutWithDivider {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/notifications/CustomNotification.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/notifications/CustomNotification.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Notification
@@ -59,7 +59,7 @@ import pixelix.app.generated.resources.sent_a_dm
 @Composable
 fun CustomNotification(
     notification: Notification,
-    navController: NavController,
+    navController: AppNavigator,
     removeNotification: () -> Unit,
     index: Int,
     count: Int,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/notifications/NotificationsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/notifications/NotificationsComposable.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.NotificationType
 import com.daniebeler.pfpixelix.domain.service.platform.PlatformFeatures
@@ -69,7 +69,7 @@ import pixelix.app.generated.resources.you_don_t_have_any_notifications
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NotificationsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: NotificationsViewModel = injectViewModel(key = "notifications-viewmodel-key") { notificationsViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/CommentsBottomSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/CommentsBottomSheet.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.Instance
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -87,7 +87,7 @@ import pixelix.app.generated.resources.trash
 
 @Composable
 fun CommentsBottomSheet(
-    post: Post, navController: NavController, viewModel: PostViewModel
+    post: Post, navController: AppNavigator, viewModel: PostViewModel
 ) {
     val suggestionsState by viewModel.hashtagMentionsSuggestionsManager.suggestionsState.collectAsStateWithLifecycle()
 
@@ -269,7 +269,7 @@ fun CommentsBottomSheet(
 private fun ReplyElement(
     reply: ReplyNode,
     postDescription: Boolean,
-    navController: NavController,
+    navController: AppNavigator,
     deleteReply: () -> Unit,
     myAccountId: String?,
     openUrl: (url: String) -> Unit,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/LikesBottomSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/LikesBottomSheet.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.ui.composables.states.LoadingComposable
@@ -39,7 +39,7 @@ import pixelix.app.generated.resources.no_likes_yet
 
 @Composable
 fun LikesBottomSheet(
-    viewModel: PostViewModel, navController: NavController
+    viewModel: PostViewModel, navController: AppNavigator
 ) {
     Column(
         Modifier
@@ -83,7 +83,7 @@ fun LikesBottomSheet(
 }
 
 @Composable
-private fun LikedByAccountElement(account: Account, navController: NavController) {
+private fun LikedByAccountElement(account: Account, navController: AppNavigator) {
     Row(
         modifier = Modifier
             .padding(horizontal = 12.dp, vertical = 8.dp)

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
@@ -67,7 +67,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
@@ -143,7 +143,7 @@ private enum class BottomSheetType { None, Comments, Menu, Likes }
 @Composable
 fun PostComposable(
     post: Post,
-    navController: NavController,
+    navController: AppNavigator,
     postGetsDeleted: (postId: String) -> Unit,
     setZindex: (zIndex: Float) -> Unit,
     openReplies: Boolean = false,
@@ -286,7 +286,7 @@ fun PostComposable(
 @Composable
 fun MasonryPost(
     post: Post,
-    navController: NavController,
+    navController: AppNavigator,
     roundedCornerShape: RoundedCornerShape,
     viewModel: PostViewModel = injectViewModel(key = "post" + post.id) { postViewModel }
 ) {
@@ -321,7 +321,7 @@ fun MasonryPost(
 
 @Composable
 private fun PostHeader(
-    post: Post, timeAgoText: String, navController: NavController, onMenuClick: () -> Unit
+    post: Post, timeAgoText: String, navController: AppNavigator, onMenuClick: () -> Unit
 ) {
     post.rebloggedBy?.let { reblogAccount ->
         Row(
@@ -397,7 +397,7 @@ private fun PostMediaSection(
     onLikeAnimation: () -> Unit,
     updatePost: (post: Post) -> Unit,
     fullQuality: Boolean,
-    navController: NavController
+    navController: AppNavigator
 ) {
     if (post.mediaAttachments.isNotEmpty()) {
         if (post.sensitive && !viewModel.showPost && viewModel.blurSensitiveContent) {
@@ -494,7 +494,7 @@ private fun PostMediaContent(
     onLikeAnimation: () -> Unit,
     updatePost: (post: Post) -> Unit,
     fullQuality: Boolean,
-    navController: NavController
+    navController: AppNavigator
 ) {
     if (post.mediaAttachments.count() > 1) {
         val smallestAspectRatio = post.mediaAttachments.minByOrNull {
@@ -591,7 +591,7 @@ private fun PostActionBar(
     animateBoost: () -> Unit,
     onCommentsClick: () -> Unit,
     onLikesClick: () -> Unit,
-    navController: NavController,
+    navController: AppNavigator,
     updatePost: (post: Post) -> Unit,
     hideMetadataPref: Boolean
 ) {
@@ -896,7 +896,7 @@ private fun MetadataItem(
 
 @Composable
 private fun PostLikedByRow(
-    post: Post, navController: NavController, onLikesClick: () -> Unit
+    post: Post, navController: AppNavigator, onLikesClick: () -> Unit
 ) {
     if (post.likedBy?.username?.isNotBlank() != true || post.likedBy.id.isNullOrBlank()) return
 
@@ -930,7 +930,7 @@ private fun PostBottomSheet(
     post: Post,
     viewModel: PostViewModel,
     pagerState: PagerState,
-    navController: NavController,
+    navController: AppNavigator,
     onDismiss: () -> Unit
 ) {
     if (activeSheet == BottomSheetType.None) return
@@ -996,7 +996,7 @@ fun PostImage(
     isMasonry: Boolean,
     roundedCornerShape: RoundedCornerShape,
     fullQuality: Boolean,
-    navController: NavController
+    navController: AppNavigator
 ) {
     var showHeart by remember { mutableStateOf(false) }
     val scale = animateFloatAsState(if (showHeart) 1f else 0f, label = "heart_filled animation")

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/ShareBottomSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/ShareBottomSheet.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.LocalSnackbarPresenter
 import com.daniebeler.pfpixelix.domain.model.MediaAttachment
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -62,7 +62,7 @@ fun ShareBottomSheet(
     viewModel: PostViewModel,
     post: Post,
     currentMediaAttachmentNumber: Int,
-    navController: NavController,
+    navController: AppNavigator,
     closeBottomSheet: () -> Unit
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorComposable.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
@@ -95,7 +95,7 @@ import pixelix.app.generated.resources.save
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PostEditorComposable(
-    navController: NavController,
+    navController: AppNavigator,
     uris: List<KmpUri>? = null,
     viewModel: PostEditorViewModel = injectViewModel(key = "post-editor-viewmodel-key") { newPostViewModel }
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorComposable.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
+import com.daniebeler.pfpixelix.ui.navigation.Destination
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
@@ -100,6 +101,23 @@ fun PostEditorComposable(
     viewModel: PostEditorViewModel = injectViewModel(key = "post-editor-viewmodel-key") { newPostViewModel }
 ) {
     val focusManager = LocalFocusManager.current
+    LaunchedEffect(viewModel, navController) {
+        viewModel.navigationEffects.collect { effect ->
+            when (effect) {
+                PostEditorNavigationEffect.PostCreated ->
+                    navController.navigate(Destination.HomeTabOwnProfile) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                is PostEditorNavigationEffect.PostUpdated -> {
+                    navController.popBackStack()
+                    navController.navigate(Destination.Post(effect.postId, refresh = true)) {
+                        launchSingleTop = true
+                    }
+                }
+            }
+        }
+    }
     var showReleaseAlert by remember {
         mutableStateOf(false)
     }
@@ -417,7 +435,7 @@ fun PostEditorComposable(
             }, confirmButton = {
                 TextButton(onClick = {
                     showReleaseAlert = false
-                    viewModel.submitPost(navController)
+                    viewModel.submitPost()
                 }) {
                     Text(stringResource(Res.string.release))
                 }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorNavigationEffect.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorNavigationEffect.kt
@@ -1,0 +1,6 @@
+package com.daniebeler.pfpixelix.ui.composables.post_editor
+
+sealed interface PostEditorNavigationEffect {
+    data object PostCreated : PostEditorNavigationEffect
+    data class PostUpdated(val postId: String) : PostEditorNavigationEffect
+}

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorViewModel.kt
@@ -9,7 +9,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 import co.touchlab.kermit.Logger
 import com.daniebeler.pfpixelix.domain.model.Instance
 import com.daniebeler.pfpixelix.domain.model.License
@@ -31,7 +32,6 @@ import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.domain.service.suggestions.HashtagMentionsSuggestionsManager
 import com.daniebeler.pfpixelix.domain.service.utils.Resource
 import com.daniebeler.pfpixelix.ui.composables.profile.AccountState
-import com.daniebeler.pfpixelix.ui.navigation.Destination
 import com.daniebeler.pfpixelix.utils.BlurHashEncoder
 import com.daniebeler.pfpixelix.utils.KmpUri
 import com.daniebeler.pfpixelix.utils.io
@@ -230,7 +230,10 @@ class PostEditorViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    fun submitPost(navController: AppNavigator) {
+    private val navigationEffectChannel = Channel<PostEditorNavigationEffect>(Channel.BUFFERED)
+    val navigationEffects = navigationEffectChannel.receiveAsFlow()
+
+    fun submitPost() {
         if (mediaItems.find { it.isLoading } != null) return // Wait for uploads
 
         postSubmissionState = PostSubmissionState(isLoading = true)
@@ -240,13 +243,13 @@ class PostEditorViewModel @Inject constructor(
 
         if (mode == EditorMode.CREATE) {
             mediaUploadState = sortMediaUploadState(mediaUploadState)
-            createNewPost(mediaUploadState, navController)
+            createNewPost(mediaUploadState)
         } else {
-            updateExistingPost(navController)
+            updateExistingPost()
         }
     }
 
-    private fun updateExistingPost(navController: AppNavigator) {
+    private fun updateExistingPost() {
         val postId = editingPostId ?: return
         val mediaIds = mediaItems.mapNotNull { it.id }
         val locationIdNullable = locationId.ifBlank { null }
@@ -265,10 +268,9 @@ class PostEditorViewModel @Inject constructor(
         postEditorService.updatePost(postId, updateRequest).onEach { result ->
             postSubmissionState = when (result) {
                 is Resource.Success -> {
-                    navController.popBackStack()
-                    navController.navigate(Destination.Post(postId, refresh = true)) {
-                        launchSingleTop = true
-                    }
+                    navigationEffectChannel.trySend(
+                        PostEditorNavigationEffect.PostUpdated(postId)
+                    )
                     PostSubmissionState()
                 }
 
@@ -665,7 +667,7 @@ class PostEditorViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    private fun createNewPost(newMediaUploadState: MediaUploadState, navController: AppNavigator) {
+    private fun createNewPost(newMediaUploadState: MediaUploadState) {
         val mediaIds = newMediaUploadState.mediaAttachments.map { it.id }
         val locationIdNullable = locationId.ifBlank {
             null
@@ -683,14 +685,7 @@ class PostEditorViewModel @Inject constructor(
         postEditorService.createPost(createPostDto).onEach { result ->
             postSubmissionState = when (result) {
                 is Resource.Success -> {
-                    navController.navigate(Destination.HomeTabOwnProfile) {
-                        launchSingleTop = true
-                        restoreState = true
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            inclusive = false
-                            saveState = true
-                        }
-                    }
+                    navigationEffectChannel.trySend(PostEditorNavigationEffect.PostCreated)
                     PostSubmissionState()
                 }
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post_editor/PostEditorViewModel.kt
@@ -9,8 +9,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import co.touchlab.kermit.Logger
 import com.daniebeler.pfpixelix.domain.model.Instance
 import com.daniebeler.pfpixelix.domain.model.License
@@ -231,7 +230,7 @@ class PostEditorViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    fun submitPost(navController: NavController) {
+    fun submitPost(navController: AppNavigator) {
         if (mediaItems.find { it.isLoading } != null) return // Wait for uploads
 
         postSubmissionState = PostSubmissionState(isLoading = true)
@@ -247,7 +246,7 @@ class PostEditorViewModel @Inject constructor(
         }
     }
 
-    private fun updateExistingPost(navController: NavController) {
+    private fun updateExistingPost(navController: AppNavigator) {
         val postId = editingPostId ?: return
         val mediaIds = mediaItems.mapNotNull { it.id }
         val locationIdNullable = locationId.ifBlank { null }
@@ -666,7 +665,7 @@ class PostEditorViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    private fun createNewPost(newMediaUploadState: MediaUploadState, navController: NavController) {
+    private fun createNewPost(newMediaUploadState: MediaUploadState, navController: AppNavigator) {
         val mediaIds = newMediaUploadState.mediaAttachments.map { it.id }
         val locationIdNullable = locationId.ifBlank {
             null

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/CollectionsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/CollectionsComposable.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.ui.composables.widgets.InfiniteListHandler
 import com.daniebeler.pfpixelix.ui.navigation.Destination
@@ -48,7 +48,7 @@ import pixelix.app.generated.resources.new_collection
 fun CollectionsComposable(
     collectionsState: CollectionsState,
     getMoreCollections: () -> Unit,
-    navController: NavController,
+    navController: AppNavigator,
     addNewButton: Boolean = false,
     instanceDomain: String,
     openUrl: (url: String) -> Unit

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/MutualFollowersComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/MutualFollowersComposable.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.ui.composables.custom_account.AccountListItem
 import com.daniebeler.pfpixelix.ui.navigation.Destination
@@ -52,7 +52,7 @@ import pixelix.app.generated.resources.others
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun MutualFollowersComposable(
-    mutualFollowersState: MutualFollowersState, navController: NavController
+    mutualFollowersState: MutualFollowersState, navController: AppNavigator
 ) {
 
     val normalStyle = SpanStyle(color = MaterialTheme.colorScheme.onBackground)

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/PostsWrapperComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/PostsWrapperComposable.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Post
 import com.daniebeler.pfpixelix.domain.model.uiKey
 import com.daniebeler.pfpixelix.ui.composables.post.MasonryPost
@@ -40,7 +40,7 @@ fun LazyStaggeredGridScope.postsWrapperComposable(
     isFirstImageLarge: Boolean = false,
     gridColumnCount: Int,
     gridContentWidth: Dp,
-    navController: NavController,
+    navController: AppNavigator,
     edit: Boolean = false,
     editRemove: (postId: String) -> Unit = { },
     onClick: ((id: String) -> Unit)? = null
@@ -105,7 +105,7 @@ private fun LazyStaggeredGridScope.postsGridInScope(
     isFirstImageLarge: Boolean = false,
     columnCount: Int = 3,
     contentWidth: Dp = 0.dp,
-    navController: NavController,
+    navController: AppNavigator,
     edit: Boolean = false,
     editRemove: (postId: String) -> Unit = { },
     onClick: ((id: String) -> Unit)? = null
@@ -274,7 +274,7 @@ private fun LazyStaggeredGridScope.postsListInScope(
     endReached: Boolean,
     postGetsDeleted: (postId: String) -> Unit,
     updatePost: (post: Post) -> Unit,
-    navController: NavController,
+    navController: AppNavigator,
 ) {
     val spacedBy: Dp = 24.dp
 
@@ -319,7 +319,7 @@ private fun LazyStaggeredGridScope.postsMasonryInScope(
     isRefreshing: Boolean,
     endReached: Boolean,
     columnCount: Int,
-    navController: NavController,
+    navController: AppNavigator,
 ) {
 
     if (posts.isNotEmpty()) {
@@ -366,7 +366,7 @@ private fun LazyStaggeredGridScope.postsLargeMasonryInScope(
     isRefreshing: Boolean,
     endReached: Boolean,
     columnCount: Int = 1,
-    navController: NavController,
+    navController: AppNavigator,
 ) {
 
     if (posts.isNotEmpty()) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/ProfileTopSection.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/ProfileTopSection.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.domain.model.Relationship
@@ -70,7 +70,7 @@ fun ProfileTopSection(
     postsLabel: String,
     followerLabel: String,
     followingLabel: String,
-    navController: NavController,
+    navController: AppNavigator,
     openUrl: (url: String) -> Unit
 ) {
     var isMuteInfoAlertOpen by remember { mutableStateOf(false) }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
@@ -127,7 +127,18 @@ fun OtherProfileComposable(
     var showUnBlockAlert by remember { mutableStateOf(false) }
 
     LaunchedEffect(userId, username) {
-        viewModel.loadData(userId, username, false, navController)
+        viewModel.loadData(userId, username, false)
+    }
+    LaunchedEffect(viewModel, navController) {
+        viewModel.navigationEffects.collect { effect ->
+            when (effect) {
+                OtherProfileNavigationEffect.OpenOwnProfile ->
+                    navController.navigate(Destination.HomeTabOwnProfile) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+            }
+        }
     }
 
     Scaffold(
@@ -192,7 +203,7 @@ fun OtherProfileComposable(
                 navController = navController,
                 getItemsPaginated = { viewModel.getPostsPaginated(viewModel.userId) },
                 onRefresh = {
-                    viewModel.loadData(userId, username, true, navController)
+                    viewModel.loadData(userId, username, true)
                 },
                 postsCount = viewModel.accountState.account?.postsCount,
                 itemGetsDeleted = { postId -> viewModel.postGetsDeleted(postId) },

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Account
@@ -112,7 +112,7 @@ import pixelix.app.generated.resources.unmute_this_profile
 )
 @Composable
 fun OtherProfileComposable(
-    navController: NavController,
+    navController: AppNavigator,
     userId: String?,
     username: String?,
     viewModel: OtherProfileViewModel = injectViewModel(key = "other-profile$userId$username") { otherProfileViewModel }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileComposable.kt
@@ -133,10 +133,7 @@ fun OtherProfileComposable(
         viewModel.navigationEffects.collect { effect ->
             when (effect) {
                 OtherProfileNavigationEffect.OpenOwnProfile ->
-                    navController.navigate(Destination.HomeTabOwnProfile) {
-                        launchSingleTop = true
-                        restoreState = true
-                    }
+                    navController.clearAndNavigate(Destination.HomeTabOwnProfile)
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileNavigationEffect.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileNavigationEffect.kt
@@ -1,0 +1,5 @@
+package com.daniebeler.pfpixelix.ui.composables.profile.other_profile
+
+sealed interface OtherProfileNavigationEffect {
+    data object OpenOwnProfile : OtherProfileNavigationEffect
+}

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileViewModel.kt
@@ -6,7 +6,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.domain.model.MutedAccount
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -29,7 +30,6 @@ import com.daniebeler.pfpixelix.ui.composables.profile.MutualFollowersState
 import com.daniebeler.pfpixelix.ui.composables.profile.PostsState
 import com.daniebeler.pfpixelix.ui.composables.profile.RelationshipState
 import com.daniebeler.pfpixelix.ui.composables.profile.ViewEnum
-import com.daniebeler.pfpixelix.ui.navigation.Destination
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -68,6 +68,9 @@ class OtherProfileViewModel(
     var followerLabel by mutableStateOf("")
     var followingLabel by mutableStateOf("")
 
+    private val navigationEffectChannel = Channel<OtherProfileNavigationEffect>(Channel.BUFFERED)
+    val navigationEffects = navigationEffectChannel.receiveAsFlow()
+
     val mutedAccount: MutedAccount?
         get() {
             val account = accountState.account ?: return null
@@ -85,7 +88,7 @@ class OtherProfileViewModel(
         }
 
     fun loadData(
-        userId: String?, username: String?, refreshing: Boolean, navController: AppNavigator
+        userId: String?, username: String?, refreshing: Boolean
     ) {
         if (username == null) {
             if (session.backendType.value == BackendType.VERNISSAGE) {
@@ -96,7 +99,7 @@ class OtherProfileViewModel(
             return
         }
         if (userId == null) {
-            loadDataByUsername(username, false, navController)
+            loadDataByUsername(username, false)
             return
         }
         val credentials = authService.getCurrentSession()
@@ -105,14 +108,8 @@ class OtherProfileViewModel(
         val myUsername = credentials?.username
 
         if (userId == myAccountId || userId == myUsername) {
-            navController.navigate(Destination.HomeTabOwnProfile) {
-                launchSingleTop = true
-                restoreState = true
-                popUpTo(navController.graph.findStartDestination().id) {
-                    inclusive = false
-                    saveState = false
-                }
-            }
+            navigationEffectChannel.trySend(OtherProfileNavigationEffect.OpenOwnProfile)
+            return
         }
 
         this.userId = userId
@@ -153,11 +150,11 @@ class OtherProfileViewModel(
         }
     }
 
-    fun loadDataByUsername(username: String, refreshing: Boolean, navController: AppNavigator) {
+    fun loadDataByUsername(username: String, refreshing: Boolean) {
         val myUsername = authService.getCurrentSession()!!.username
         if (username == myUsername) {
-            navController.popBackStack()
-            navController.navigate(Destination.OwnProfile)
+            navigationEffectChannel.trySend(OtherProfileNavigationEffect.OpenOwnProfile)
+            return
         }
         getAccountByUsername(username, refreshing)
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/other_profile/OtherProfileViewModel.kt
@@ -6,8 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.domain.model.MutedAccount
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -86,7 +85,7 @@ class OtherProfileViewModel(
         }
 
     fun loadData(
-        userId: String?, username: String?, refreshing: Boolean, navController: NavController
+        userId: String?, username: String?, refreshing: Boolean, navController: AppNavigator
     ) {
         if (username == null) {
             if (session.backendType.value == BackendType.VERNISSAGE) {
@@ -154,7 +153,7 @@ class OtherProfileViewModel(
         }
     }
 
-    fun loadDataByUsername(username: String, refreshing: Boolean, navController: NavController) {
+    fun loadDataByUsername(username: String, refreshing: Boolean, navController: AppNavigator) {
         val myUsername = authService.getCurrentSession()!!.username
         if (username == myUsername) {
             navController.popBackStack()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/AccountSwitchBottomSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/AccountSwitchBottomSheet.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.model.Credentials
@@ -54,7 +54,7 @@ import pixelix.app.generated.resources.remove_account
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AccountSwitchBottomSheet(
-    navController: NavController,
+    navController: AppNavigator,
     closeBottomSheet: () -> Unit,
     ownProfileViewModel: OwnProfileViewModel?,
     viewModel: AccountSwitchViewModel = injectViewModel(key = "account_switcher_viewmodel") { accountSwitchViewModel }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/ModalBottomSheetContent.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/ModalBottomSheetContent.kt
@@ -9,7 +9,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.ui.composables.widgets.ButtonRowElement
 import com.daniebeler.pfpixelix.ui.navigation.Destination
@@ -35,7 +35,7 @@ import pixelix.app.generated.resources.vernissage_logo
 
 @Composable
 fun ModalBottomSheetContent(
-    navController: NavController,
+    navController: AppNavigator,
     instanceDomain: String,
     appIcon: DrawableResource,
     backendType: BackendType,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/OwnProfileComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/profile/own_profile/OwnProfileComposable.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.service.platform.PlatformFeatures
 import com.daniebeler.pfpixelix.ui.composables.profile.CollectionsComposable
@@ -63,7 +63,7 @@ import pixelix.app.generated.resources.user_switch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OwnProfileComposable(
-    navController: NavController,
+    navController: AppNavigator,
     openPreferencesDrawer: () -> Unit,
     viewModel: OwnProfileViewModel = injectViewModel(key = "own-profile-key") { ownProfileViewModel }
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/session/LoginComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/session/LoginComposable.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
@@ -84,7 +84,7 @@ import pixelix.app.generated.resources.vernissage_full_logo_white
 @Composable
 fun LoginComposable(
     isCloseable: Boolean = false,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: LoginViewModel = injectViewModel("LoginViewModel") { loginViewModel }
 ) {
     val dark = MaterialTheme.colorScheme.background.luminance() < 0.5

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/session/LoginViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/session/LoginViewModel.kt
@@ -75,13 +75,20 @@ class LoginViewModel(
     }
 
     fun auth() {
-        session.setBackendType(selectedPlatform ?: BackendType.PIXELFED)
+        // This must happen synchronously in the click handler for mobile popup policies.
+        val backendType = selectedPlatform ?: BackendType.PIXELFED
+        if (!platform.prepareAuthBrowser(serverHost.text, backendType)) {
+            error = "The browser blocked the login window. Allow pop-ups and try again."
+            return
+        }
+        session.setBackendType(backendType)
         viewModelScope.launch {
             try {
                 isLoading = true
                 error = null
                 authService.auth(serverHost.text)
             } catch (e: Throwable) {
+                platform.dismissBrowser()
                 error = e.message
             } finally {
                 isLoading = false

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/about_instance/AboutInstanceComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/about_instance/AboutInstanceComposable.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.service.general.BackendType
@@ -51,7 +51,7 @@ import pixelix.app.generated.resources.users
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AboutInstanceComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: AboutInstanceViewModel = injectViewModel(key = "about-instance-key") { aboutInstanceViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/about_pixelix/AboutPixelixComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/about_pixelix/AboutPixelixComposable.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.widgets.ButtonRowElement
 import com.daniebeler.pfpixelix.ui.composables.widgets.ScreenScaffold
@@ -50,7 +50,7 @@ import pixelix.app.generated.resources.website
 
 @Composable
 fun AboutPixelixComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: AboutPixelixViewModel = injectViewModel(key = "about-pixelix-viewmodel-key") { aboutPixelixViewModel }
 ) {
     val scrollState = rememberScrollState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/blocked_accounts/BlockedAccountsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/blocked_accounts/BlockedAccountsComposable.kt
@@ -2,7 +2,7 @@ package com.daniebeler.pfpixelix.ui.composables.settings.blocked_accounts
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.widgets.AccountListScreen
 import org.jetbrains.compose.resources.stringResource
@@ -12,7 +12,7 @@ import pixelix.app.generated.resources.no_blocked_accounts
 
 @Composable
 fun BlockedAccountsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: BlockedAccountsViewModel = injectViewModel(key = "blocked-accounts-key") { blockedAccountsViewModel }
 ) {
     AccountListScreen(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/blocked_accounts/CustomBlockedAccountRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/blocked_accounts/CustomBlockedAccountRow.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.ui.composables.profile.other_profile.UnBlockAccountAlert
@@ -29,7 +29,7 @@ import pixelix.app.generated.resources.unblock
 
 @Composable
 fun CustomBlockedAccountRow(
-    account: Account, navController: NavController, viewModel: BlockedAccountsViewModel
+    account: Account, navController: AppNavigator, viewModel: BlockedAccountsViewModel
 ) {
     Row(
         Modifier

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/bookmarked_posts/BookmarkedPostsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/bookmarked_posts/BookmarkedPostsComposable.kt
@@ -1,7 +1,7 @@
 package com.daniebeler.pfpixelix.ui.composables.settings.bookmarked_posts
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.ParametricTimelineViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.TimelineScreen
@@ -11,7 +11,7 @@ import pixelix.app.generated.resources.bookmarked_posts
 
 @Composable
 fun BookmarkedPostsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "bookmarked-posts") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.BOOKMARKED_POSTS) }
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/followed_hashtags/FollowedHashtagsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/followed_hashtags/FollowedHashtagsComposable.kt
@@ -12,7 +12,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyStateComposable
@@ -32,7 +32,7 @@ import pixelix.app.generated.resources.no_followed_hashtags
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun FollowedHashtagsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: FollowedHashtagsViewModel = injectViewModel(key = "followed-hashtags-key") { followedHashtagsViewModel }
 ) {
     ScreenScaffold(title = stringResource(Res.string.followed_hashtags), navController = navController) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/icon_selection/IconSelectionComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/icon_selection/IconSelectionComposable.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
@@ -57,7 +57,7 @@ import pixelix.app.generated.resources.change_app_icon_dialog_content
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun IconSelectionComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: IconSelectionViewModel = injectViewModel(key = "iconselectionvm") { iconSelectionViewModel }
 ) {
     val lazyGridState = rememberLazyGridState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/liked_posts/LikedPostsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/liked_posts/LikedPostsComposable.kt
@@ -1,7 +1,7 @@
 package com.daniebeler.pfpixelix.ui.composables.settings.liked_posts
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.ParametricTimelineViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.TimelineScreen
@@ -11,7 +11,7 @@ import pixelix.app.generated.resources.liked_posts
 
 @Composable
 fun LikedPostsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "liked-posts") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.LIKED_POSTS) }
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/muted_accounts/CustomMutedAccountRow.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/muted_accounts/CustomMutedAccountRow.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.domain.model.MutedAccount
 import com.daniebeler.pfpixelix.ui.navigation.Destination
@@ -29,7 +29,7 @@ import pixelix.app.generated.resources.unmute
 @Composable
 fun CustomMutedAccountRow(
     mutedAccount: MutedAccount,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: MutedAccountsViewModel,
 ) {
     Row(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/muted_accounts/MutedAccountsComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/muted_accounts/MutedAccountsComposable.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyStateComposable
@@ -26,7 +26,7 @@ import pixelix.app.generated.resources.no_muted_accounts
 
 @Composable
 fun MutedAccountsComposable(
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: MutedAccountsViewModel = injectViewModel(key = "muted-accounts-key") { mutedAccountsViewModel }
 ) {
     ScreenScaffold(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/preferences/prefs/PreferencesComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/preferences/prefs/PreferencesComposable.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.domain.service.platform.PlatformFeatures
 import com.daniebeler.pfpixelix.ui.composables.settings.preferences.prefs.prefs.AutoplayVideoPref
@@ -62,7 +62,7 @@ import pixelix.app.generated.resources.settings
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PreferencesComposable(
-    navController: NavController,
+    navController: AppNavigator,
     drawerState: DrawerState,
     closePreferencesDrawer: () -> Unit,
     viewModel: PreferencesViewModel = injectViewModel(key = "preferences-viewmodel-key") { preferencesViewModel }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/preferences/prefs/prefs/CustomizeAppIconPref.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/settings/preferences/prefs/prefs/CustomizeAppIconPref.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.ui.composables.settings.preferences.prefs.basic.SettingPref
 import com.daniebeler.pfpixelix.ui.navigation.Destination
 import org.jetbrains.compose.resources.DrawableResource
@@ -25,7 +25,7 @@ import pixelix.app.generated.resources.customize_app_icon
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun CustomizeAppIconPref(
-    navController: NavController, closePreferenceDrawer: () -> Unit, logo: DrawableResource
+    navController: AppNavigator, closePreferenceDrawer: () -> Unit, logo: DrawableResource
 ) {
     SettingPref(leadingContent = {
         Image(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/single_post/SinglePostComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/single_post/SinglePostComposable.kt
@@ -26,8 +26,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.post.PostComposable
 import com.daniebeler.pfpixelix.ui.composables.states.ErrorComposable
@@ -44,7 +43,7 @@ import pixelix.app.generated.resources.post
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SinglePostComposable(
-    navController: NavController,
+    navController: AppNavigator,
     postId: String,
     refresh: Boolean,
     openReplies: Boolean,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/global_timeline/GlobalTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/global_timeline/GlobalTimelineComposable.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.LocalAppComponent
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.TimelineHelpCard
@@ -19,7 +19,7 @@ import pixelix.app.generated.resources.global_timeline_explained
 fun GlobalTimelineComposable(
     pagerState: PagerState,
     tabIndex: Int,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: GlobalTimelineViewModel = injectViewModel(key = "global-timeline-key") { globalTimelineViewModel }
 ) {
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/hashtag_timeline/HashtagTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/hashtag_timeline/HashtagTimelineComposable.kt
@@ -2,14 +2,14 @@ package com.daniebeler.pfpixelix.ui.composables.timelines.hashtag_timeline
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.TimelineScreen
 import com.daniebeler.pfpixelix.ui.composables.widgets.FollowButton
 
 @Composable
 fun HashtagTimelineComposable(
-    navController: NavController,
+    navController: AppNavigator,
     hashtag: String,
     viewModel: HashtagTimelineViewModel = injectViewModel(key = "hashtag-timeline-$hashtag") { hashtagTimelineViewModel }
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/home_timeline/HomeTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/home_timeline/HomeTimelineComposable.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.LocalAppComponent
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -26,7 +26,7 @@ import pixelix.app.generated.resources.photo
 fun HomeTimelineComposable(
     pagerState: PagerState,
     tabIndex: Int,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: HomeTimelineViewModel = injectViewModel(key = "home-timeline-key") { homeTimelineViewModel }
 ) {
     val staggeredGridState = rememberLazyStaggeredGridState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/local_timeline/LocalTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/local_timeline/LocalTimelineComposable.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.LocalAppComponent
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
@@ -20,7 +20,7 @@ import pixelix.app.generated.resources.local_timeline_explained
 fun LocalTimelineComposable(
     pagerState: PagerState,
     tabIndex: Int,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: LocalTimelineViewModel = injectViewModel(key = "local-timeline-key") { localTimelineViewModel }
 ) {
     val staggeredGridState = rememberLazyStaggeredGridState()

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/CameraTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/CameraTimelineComposable.kt
@@ -1,12 +1,12 @@
 package com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 
 @Composable
 fun CameraTimelineComposable(
-    navController: NavController,
+    navController: AppNavigator,
     camera: String,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "camera-$camera") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.CAMERA, camera) }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/CategoryTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/CategoryTimelineComposable.kt
@@ -1,12 +1,12 @@
 package com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 
 @Composable
 fun CategoryTimelineComposable(
-    navController: NavController,
+    navController: AppNavigator,
     category: String,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "category-$category") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.CATEGORY, category) }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/FilmTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/FilmTimelineComposable.kt
@@ -1,12 +1,12 @@
 package com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 
 @Composable
 fun FilmTimelineComposable(
-    navController: NavController,
+    navController: AppNavigator,
     film: String,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "film-$film") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.FILM, film) }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/LensTimelineComposable.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/LensTimelineComposable.kt
@@ -1,12 +1,12 @@
 package com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.di.injectViewModel
 
 @Composable
 fun LensTimelineComposable(
-    navController: NavController,
+    navController: AppNavigator,
     lens: String,
     viewModel: ParametricTimelineViewModel = injectViewModel(key = "lens-$lens") {
         parametricTimelineViewModel.apply { init(ParametricTimelineViewModel.FetchType.LENS, lens) }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/TimelineScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/timelines/parametric_timeline_screens/TimelineScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
 import com.daniebeler.pfpixelix.ui.composables.widgets.InfinitePostsList
 import com.daniebeler.pfpixelix.ui.composables.widgets.PaginatedPostsViewModel
@@ -21,7 +21,7 @@ import pixelix.app.generated.resources.photo
 fun TimelineScreen(
     title: String,
     subtitle: String? = null,
-    navController: NavController,
+    navController: AppNavigator,
     viewModel: PaginatedPostsViewModel,
     actions: @Composable RowScope.() -> Unit = {},
     contentPaddingTop: Dp = 24.dp,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/AccountListScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/AccountListScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Account
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyState
 import com.daniebeler.pfpixelix.ui.composables.states.EmptyStateComposable
@@ -24,7 +24,7 @@ import com.daniebeler.pfpixelix.ui.composables.states.LoadingComposable
 @Composable
 fun AccountListScreen(
     title: String,
-    navController: NavController,
+    navController: AppNavigator,
     items: List<Account>,
     isLoading: Boolean,
     isRefreshing: Boolean,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/CustomHashtag.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/CustomHashtag.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Tag
 import com.daniebeler.pfpixelix.ui.navigation.Destination
 import org.jetbrains.compose.resources.vectorResource
@@ -30,7 +30,7 @@ import pixelix.app.generated.resources.hash
 @Composable
 fun CustomHashtag(
     hashtag: Tag,
-    navController: NavController,
+    navController: AppNavigator,
     onClick: () -> Unit = {}
 ) {
     Row(

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/CustomPost.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/CustomPost.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import coil3.compose.AsyncImage
 import com.daniebeler.pfpixelix.di.LocalAppComponent
 import com.daniebeler.pfpixelix.domain.model.Post
@@ -36,7 +36,7 @@ private const val DEFAULT_BLUR_HASH = "LEHLk~WB2yk8pyo0adR*.7kCMdnj"
 @Composable
 fun CustomPost(
     post: Post,
-    navController: NavController,
+    navController: AppNavigator,
     modifier: Modifier = Modifier,
     isFullQuality: Boolean = false,
     onClick: ((id: String) -> Unit)? = null,

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/InfinitePostsList.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/InfinitePostsList.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import com.daniebeler.pfpixelix.domain.model.Post
 import com.daniebeler.pfpixelix.ui.composables.profile.SwitchViewComposable
 import com.daniebeler.pfpixelix.ui.composables.profile.ViewEnum
@@ -39,7 +39,7 @@ fun InfinitePostsList(
     isRefreshing: Boolean,
     error: String,
     endReached: Boolean,
-    navController: NavController,
+    navController: AppNavigator,
     getItemsPaginated: () -> Unit,
     emptyMessage: EmptyState = EmptyState(
         icon = vectorResource(Res.drawable.photo), heading = "No Posts"

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/ScreenScaffold.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/widgets/ScreenScaffold.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
+import com.daniebeler.pfpixelix.ui.navigation.AppNavigator
 import org.jetbrains.compose.resources.vectorResource
 import pixelix.app.generated.resources.Res
 import pixelix.app.generated.resources.arrow_left
@@ -33,7 +33,7 @@ import pixelix.app.generated.resources.arrow_left
 fun ScreenScaffold(
     title: String,
     subtitle: String? = null,
-    navController: NavController,
+    navController: AppNavigator,
     actions: @Composable RowScope.() -> Unit = {},
     content: @Composable () -> Unit
 ) {

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
@@ -1,0 +1,106 @@
+package com.daniebeler.pfpixelix.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.savedstate.serialization.SavedStateConfiguration
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+
+internal val navigationSavedStateConfiguration = SavedStateConfiguration {
+    serializersModule = SerializersModule {
+        polymorphic(NavKey::class) {
+            subclass(Destination::class, Destination.serializer())
+        }
+    }
+}
+
+internal val topLevelDestinations: Set<Destination> = setOf(
+    Destination.HomeTabFeeds,
+    Destination.HomeTabSearch,
+    Destination.HomeTabNewPost,
+    Destination.HomeTabNotifications,
+    Destination.HomeTabOwnProfile,
+)
+
+@Composable
+internal fun rememberAppNavigationState(
+    startDestination: Destination,
+): AppNavigationState {
+    val currentTopLevel = remember(startDestination) {
+        mutableStateOf(startDestination)
+    }
+
+    val stacks = topLevelDestinations.associateWith { destination ->
+        rememberNavBackStack(navigationSavedStateConfiguration, destination)
+    }.toMutableMap()
+
+    if (startDestination !in stacks) {
+        stacks[startDestination] = rememberNavBackStack(
+            navigationSavedStateConfiguration,
+            startDestination,
+        )
+    }
+
+    return remember(startDestination) {
+        AppNavigationState(
+            startDestination = startDestination,
+            currentTopLevelState = currentTopLevel,
+            backStacks = stacks,
+        )
+    }
+}
+
+internal class AppNavigationState(
+    val startDestination: Destination,
+    private val currentTopLevelState: MutableState<Destination>,
+    val backStacks: Map<Destination, NavBackStack<NavKey>>,
+) {
+    var currentTopLevel: Destination
+        get() = currentTopLevelState.value
+        set(value) {
+            currentTopLevelState.value = value
+        }
+
+    val currentBackStack: NavBackStack<NavKey>
+        get() = checkNotNull(backStacks[currentTopLevel]) {
+            "No back stack registered for $currentTopLevel"
+        }
+
+    val currentDestination: Destination
+        get() = currentBackStack.last() as Destination
+
+    @Composable
+    fun decoratedEntries(
+        entryProvider: (NavKey) -> NavEntry<NavKey>,
+    ): List<NavEntry<NavKey>> {
+        val entriesByStack = backStacks.mapValues { (_, stack) ->
+            rememberDecoratedNavEntries(
+                backStack = stack,
+                entryDecorators = listOf(
+                    rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                ),
+                entryProvider = entryProvider,
+            )
+        }
+
+        val stacksInUse = if (
+            currentTopLevel == startDestination || startDestination !in topLevelDestinations
+        ) {
+            listOf(currentTopLevel)
+        } else {
+            listOf(startDestination, currentTopLevel)
+        }
+        return stacksInUse.flatMap { entriesByStack[it].orEmpty() }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
@@ -2,10 +2,8 @@ package com.daniebeler.pfpixelix.ui.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
@@ -21,7 +19,42 @@ import kotlinx.serialization.modules.subclass
 internal val navigationSavedStateConfiguration = SavedStateConfiguration {
     serializersModule = SerializersModule {
         polymorphic(NavKey::class) {
-            subclass(Destination::class, Destination.serializer())
+            subclass(Destination.Hashtag::class, Destination.Hashtag.serializer())
+            subclass(Destination.HashtagTimeline::class, Destination.HashtagTimeline.serializer())
+            subclass(Destination.CameraTimeline::class, Destination.CameraTimeline.serializer())
+            subclass(Destination.CategoryTimeline::class, Destination.CategoryTimeline.serializer())
+            subclass(Destination.LensTimeline::class, Destination.LensTimeline.serializer())
+            subclass(Destination.FilmTimeline::class, Destination.FilmTimeline.serializer())
+            subclass(Destination.Post::class, Destination.Post.serializer())
+            subclass(Destination.EditPost::class, Destination.EditPost.serializer())
+            subclass(Destination.Collection::class, Destination.Collection.serializer())
+            subclass(Destination.Followers::class, Destination.Followers.serializer())
+            subclass(Destination.Conversations::class, Destination.Conversations.serializer())
+            subclass(Destination.Chat::class, Destination.Chat.serializer())
+            subclass(Destination.Mention::class, Destination.Mention.serializer())
+            subclass(Destination.EditProfile::class, Destination.EditProfile.serializer())
+            subclass(Destination.IconSelection::class, Destination.IconSelection.serializer())
+            subclass(Destination.MutedAccounts::class, Destination.MutedAccounts.serializer())
+            subclass(Destination.BlockedAccounts::class, Destination.BlockedAccounts.serializer())
+            subclass(Destination.LikedPosts::class, Destination.LikedPosts.serializer())
+            subclass(Destination.BookmarkedPosts::class, Destination.BookmarkedPosts.serializer())
+            subclass(Destination.FollowedHashtags::class, Destination.FollowedHashtags.serializer())
+            subclass(Destination.AboutInstance::class, Destination.AboutInstance.serializer())
+            subclass(Destination.AboutPixelix::class, Destination.AboutPixelix.serializer())
+            subclass(Destination.Profile::class, Destination.Profile.serializer())
+            subclass(Destination.ProfileByUsername::class, Destination.ProfileByUsername.serializer())
+            subclass(Destination.FirstLogin::class, Destination.FirstLogin.serializer())
+            subclass(Destination.NewLogin::class, Destination.NewLogin.serializer())
+            subclass(Destination.Search::class, Destination.Search.serializer())
+            subclass(Destination.OwnProfile::class, Destination.OwnProfile.serializer())
+            subclass(Destination.Feeds::class, Destination.Feeds.serializer())
+            subclass(Destination.NewPost::class, Destination.NewPost.serializer())
+            subclass(Destination.Notifications::class, Destination.Notifications.serializer())
+            subclass(Destination.HomeTabFeeds::class, Destination.HomeTabFeeds.serializer())
+            subclass(Destination.HomeTabSearch::class, Destination.HomeTabSearch.serializer())
+            subclass(Destination.HomeTabNewPost::class, Destination.HomeTabNewPost.serializer())
+            subclass(Destination.HomeTabNotifications::class, Destination.HomeTabNotifications.serializer())
+            subclass(Destination.HomeTabOwnProfile::class, Destination.HomeTabOwnProfile.serializer())
         }
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigationState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
@@ -89,6 +90,7 @@ internal class AppNavigationState(
                 backStack = stack,
                 entryDecorators = listOf(
                     rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                    rememberViewModelStoreNavEntryDecorator<NavKey>(),
                 ),
                 entryProvider = entryProvider,
             )

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigator.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigator.kt
@@ -3,17 +3,28 @@ package com.daniebeler.pfpixelix.ui.navigation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-internal class AppNavigator(
+class AppNavigator internal constructor(
     private val state: AppNavigationState,
     private val exitApp: () -> Unit,
 ) {
     private val _reselectEvents = MutableSharedFlow<Destination>(extraBufferCapacity = 1)
     val reselectEvents = _reselectEvents.asSharedFlow()
+    val graph = NavigationGraph()
 
-    fun navigate(destination: Destination) {
+    fun navigate(
+        destination: Destination,
+        options: NavigationOptions.() -> Unit = {},
+    ) {
+        val navigationOptions = NavigationOptions().apply(options)
         if (destination in state.backStacks) {
             state.currentTopLevel = destination
-        } else {
+            if (!navigationOptions.restoreState) {
+                state.currentBackStack.apply {
+                    clear()
+                    add(destination)
+                }
+            }
+        } else if (!navigationOptions.launchSingleTop || state.currentDestination != destination) {
             state.currentBackStack.add(destination)
         }
     }
@@ -62,6 +73,17 @@ internal class AppNavigator(
         }
     }
 
+    fun navigateUp(): Boolean = popBackStack()
+
+    fun <T : Destination> clearBackStack(destination: T): Boolean {
+        val stack = state.backStacks[destination] ?: return false
+        stack.apply {
+            clear()
+            add(destination)
+        }
+        return true
+    }
+
     fun resetForSession(startDestination: Destination) {
         state.backStacks.forEach { (root, stack) ->
             stack.clear()
@@ -71,4 +93,24 @@ internal class AppNavigator(
             state.currentTopLevel = startDestination
         }
     }
+}
+
+class NavigationGraph {
+    val id: Int = 0
+    val startDestinationId: Int = 0
+    fun findStartDestination(): NavigationGraph = this
+}
+
+class NavigationOptions {
+    var launchSingleTop: Boolean = false
+    var restoreState: Boolean = false
+
+    fun popUpTo(@Suppress("UNUSED_PARAMETER") route: Any, options: PopUpToOptions.() -> Unit = {}) {
+        PopUpToOptions().apply(options)
+    }
+}
+
+class PopUpToOptions {
+    var inclusive: Boolean = false
+    var saveState: Boolean = false
 }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigator.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/AppNavigator.kt
@@ -1,0 +1,74 @@
+package com.daniebeler.pfpixelix.ui.navigation
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+internal class AppNavigator(
+    private val state: AppNavigationState,
+    private val exitApp: () -> Unit,
+) {
+    private val _reselectEvents = MutableSharedFlow<Destination>(extraBufferCapacity = 1)
+    val reselectEvents = _reselectEvents.asSharedFlow()
+
+    fun navigate(destination: Destination) {
+        if (destination in state.backStacks) {
+            state.currentTopLevel = destination
+        } else {
+            state.currentBackStack.add(destination)
+        }
+    }
+
+    fun navigateTopLevel(destination: Destination) {
+        require(destination in state.backStacks) { "$destination is not a top-level destination" }
+        if (destination == state.currentTopLevel) {
+            _reselectEvents.tryEmit(destination)
+        } else {
+            state.currentTopLevel = destination
+        }
+    }
+
+    fun replaceTop(destination: Destination) {
+        state.currentBackStack.removeLastOrNull()
+        state.currentBackStack.add(destination)
+    }
+
+    fun popBackStack(): Boolean {
+        if (state.currentBackStack.size > 1) {
+            state.currentBackStack.removeLastOrNull()
+            return true
+        }
+        if (state.currentTopLevel != state.startDestination &&
+            state.startDestination in state.backStacks
+        ) {
+            state.currentTopLevel = state.startDestination
+            return true
+        }
+        exitApp()
+        return false
+    }
+
+    fun clearAndNavigate(destination: Destination) {
+        if (destination in state.backStacks) {
+            state.currentTopLevel = destination
+            state.currentBackStack.apply {
+                clear()
+                add(destination)
+            }
+        } else {
+            state.currentBackStack.apply {
+                clear()
+                add(destination)
+            }
+        }
+    }
+
+    fun resetForSession(startDestination: Destination) {
+        state.backStacks.forEach { (root, stack) ->
+            stack.clear()
+            stack.add(root)
+        }
+        if (startDestination in state.backStacks) {
+            state.currentTopLevel = startDestination
+        }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
@@ -1,21 +1,9 @@
 package com.daniebeler.pfpixelix.ui.navigation
 
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.Dialog
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavDestination.Companion.hierarchy
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.dialog
-import androidx.navigation.compose.navigation
-import androidx.navigation.toRoute
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
 import com.daniebeler.pfpixelix.EdgeToEdgeDialogProperties
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.HomeComposable
@@ -26,8 +14,8 @@ import com.daniebeler.pfpixelix.ui.composables.edit_profile.EditProfileComposabl
 import com.daniebeler.pfpixelix.ui.composables.explore.ExploreComposable
 import com.daniebeler.pfpixelix.ui.composables.followers.FollowersMainComposable
 import com.daniebeler.pfpixelix.ui.composables.mention.MentionComposable
-import com.daniebeler.pfpixelix.ui.composables.post_editor.PostEditorComposable
 import com.daniebeler.pfpixelix.ui.composables.notifications.NotificationsComposable
+import com.daniebeler.pfpixelix.ui.composables.post_editor.PostEditorComposable
 import com.daniebeler.pfpixelix.ui.composables.post_editor.PostEditorViewModel
 import com.daniebeler.pfpixelix.ui.composables.profile.other_profile.OtherProfileComposable
 import com.daniebeler.pfpixelix.ui.composables.profile.own_profile.OwnProfileComposable
@@ -41,8 +29,8 @@ import com.daniebeler.pfpixelix.ui.composables.settings.icon_selection.IconSelec
 import com.daniebeler.pfpixelix.ui.composables.settings.liked_posts.LikedPostsComposable
 import com.daniebeler.pfpixelix.ui.composables.settings.muted_accounts.MutedAccountsComposable
 import com.daniebeler.pfpixelix.ui.composables.single_post.SinglePostComposable
-import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.CameraTimelineComposable
 import com.daniebeler.pfpixelix.ui.composables.timelines.hashtag_timeline.HashtagTimelineComposable
+import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.CameraTimelineComposable
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.CategoryTimelineComposable
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.FilmTimelineComposable
 import com.daniebeler.pfpixelix.ui.composables.timelines.parametric_timeline_screens.LensTimelineComposable
@@ -167,144 +155,95 @@ sealed interface Destination : NavKey {
     data object HomeTabOwnProfile : Destination
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-internal fun NavGraphBuilder.appGraph(
-    navController: NavHostController,
+internal fun appEntryProvider(
+    navigator: AppNavigator,
     openPreferencesDrawer: () -> Unit,
     exitApp: () -> Unit,
-) {
-    composable<Destination.FirstLogin>(
-        enterTransition = { EnterTransition.None },
-        exitTransition = { ExitTransition.None }) {
-        Dialog(
-            onDismissRequest = exitApp, properties = EdgeToEdgeDialogProperties()
-        ) {
-            LoginComposable(navController = navController)
+) = entryProvider<NavKey> {
+    entry<Destination.FirstLogin> {
+        Dialog(onDismissRequest = exitApp, properties = EdgeToEdgeDialogProperties()) {
+            LoginComposable(navController = navigator)
         }
     }
 
-    //home tabs (with no transition animations)
-    //more info: https://issuetracker.google.com/408010634
-    navigation<Destination.HomeTabFeeds>(
-        startDestination = Destination.Feeds,
-        enterTransition = { tabEnterTransition<Destination.HomeTabFeeds>() },
-        exitTransition = { tabExitTransition<Destination.HomeTabFeeds>() }) {
-        tabGraph(navController, openPreferencesDrawer)
+    entry<Destination.NewPost> { args ->
+        val imageUris: List<KmpUri>? = args.uris.map { it.toKmpUri() }
+        PostEditorComposable(navigator, imageUris)
     }
 
-    navigation<Destination.HomeTabSearch>(
-        startDestination = Destination.Search(),
-        enterTransition = { tabEnterTransition<Destination.HomeTabSearch>() },
-        exitTransition = { tabExitTransition<Destination.HomeTabSearch>() }) {
-        tabGraph(navController, openPreferencesDrawer)
+    entry<Destination.NewLogin> {
+        LoginComposable(true, navigator)
     }
 
-    navigation<Destination.HomeTabNewPost>(
-        startDestination = Destination.NewPost(),
-        enterTransition = { tabEnterTransition<Destination.HomeTabNewPost>() },
-        exitTransition = { tabExitTransition<Destination.HomeTabNewPost>() }) {
-
-        composable<Destination.NewPost> { navBackStackEntry ->
-            val args = navBackStackEntry.toRoute<Destination.NewPost>()
-            val imageUris: List<KmpUri>? = args.uris.map { it.toKmpUri() }
-            PostEditorComposable(navController, imageUris)
-        }
-
-        tabGraph(navController, openPreferencesDrawer)
+    entry<Destination.HomeTabFeeds> {
+        HomeComposable(navigator, openPreferencesDrawer)
     }
 
-    navigation<Destination.HomeTabNotifications>(
-        startDestination = Destination.Notifications,
-        enterTransition = { tabEnterTransition<Destination.HomeTabNotifications>() },
-        exitTransition = { tabExitTransition<Destination.HomeTabNotifications>() }) {
-        tabGraph(navController, openPreferencesDrawer)
+    entry<Destination.HomeTabSearch> {
+        ExploreComposable(navigator, 0)
     }
 
-    navigation<Destination.HomeTabOwnProfile>(
-        startDestination = Destination.OwnProfile,
-        enterTransition = { tabEnterTransition<Destination.HomeTabOwnProfile>() },
-        exitTransition = { tabExitTransition<Destination.HomeTabOwnProfile>() }) {
-        tabGraph(navController, openPreferencesDrawer)
-    }
-}
-
-private inline fun <reified T : Any> AnimatedContentTransitionScope<NavBackStackEntry>.tabEnterTransition(): EnterTransition? {
-    val initialHierarchy = initialState.destination.hierarchy
-    return if (initialHierarchy.none { it.hasRoute<T>() }) EnterTransition.None else null
-}
-
-private inline fun <reified T : Any> AnimatedContentTransitionScope<NavBackStackEntry>.tabExitTransition(): ExitTransition? {
-    val targetHierarchy = targetState.destination.hierarchy
-    return if (targetHierarchy.none { it.hasRoute<T>() }) ExitTransition.None else null
-}
-
-private fun NavGraphBuilder.tabGraph(
-    navController: NavHostController, openPreferencesDrawer: () -> Unit
-) {
-    dialog<Destination.NewLogin>(
-        dialogProperties = EdgeToEdgeDialogProperties()
-    ) {
-        LoginComposable(true, navController)
+    entry<Destination.HomeTabNewPost> {
+        PostEditorComposable(navigator, emptyList())
     }
 
-    composable<Destination.Feeds> {
-        HomeComposable(navController, openPreferencesDrawer)
+    entry<Destination.HomeTabNotifications> {
+        NotificationsComposable(navigator)
     }
 
-    composable<Destination.Notifications> {
-        NotificationsComposable(navController)
+    entry<Destination.HomeTabOwnProfile> {
+        OwnProfileComposable(navigator, openPreferencesDrawer)
     }
 
-    composable<Destination.HashtagTimeline> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.HashtagTimeline>()
-        HashtagTimelineComposable(navController, args.hashtag)
+    entry<Destination.Feeds> {
+        HomeComposable(navigator, openPreferencesDrawer)
     }
 
-    composable<Destination.CameraTimeline> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.CameraTimeline>()
-        CameraTimelineComposable(navController, args.camera)
+    entry<Destination.Notifications> {
+        NotificationsComposable(navigator)
     }
 
-    composable<Destination.CategoryTimeline> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.CategoryTimeline>()
-        CategoryTimelineComposable(navController, args.category)
+    entry<Destination.HashtagTimeline> { args ->
+        HashtagTimelineComposable(navigator, args.hashtag)
     }
 
-    composable<Destination.FilmTimeline> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.FilmTimeline>()
-        FilmTimelineComposable(navController, args.film)
+    entry<Destination.CameraTimeline> { args ->
+        CameraTimelineComposable(navigator, args.camera)
     }
 
-    composable<Destination.LensTimeline> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.LensTimeline>()
-        LensTimelineComposable(navController, args.lens)
+    entry<Destination.CategoryTimeline> { args ->
+        CategoryTimelineComposable(navigator, args.category)
     }
 
-    composable<Destination.Profile> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Profile>()
-        OtherProfileComposable(navController, userId = args.userId, username = args.username)
+    entry<Destination.FilmTimeline> { args ->
+        FilmTimelineComposable(navigator, args.film)
     }
 
-    composable<Destination.ProfileByUsername> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.ProfileByUsername>()
-        OtherProfileComposable(navController, userId = null, username = args.userName)
+    entry<Destination.LensTimeline> { args ->
+        LensTimelineComposable(navigator, args.lens)
     }
 
-    composable<Destination.Hashtag> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Hashtag>()
-        HashtagTimelineComposable(navController, args.hashtag)
+    entry<Destination.Profile> { args ->
+        OtherProfileComposable(navigator, userId = args.userId, username = args.username)
     }
 
-    composable<Destination.EditProfile> {
-        EditProfileComposable(navController)
+    entry<Destination.ProfileByUsername> { args ->
+        OtherProfileComposable(navigator, userId = null, username = args.userName)
     }
 
-    composable<Destination.IconSelection> {
-        IconSelectionComposable(navController)
+    entry<Destination.Hashtag> { args ->
+        HashtagTimelineComposable(navigator, args.hashtag)
     }
 
-    composable<Destination.EditPost> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.EditPost>()
+    entry<Destination.EditProfile> {
+        EditProfileComposable(navigator)
+    }
+
+    entry<Destination.IconSelection> {
+        IconSelectionComposable(navigator)
+    }
+
+    entry<Destination.EditPost> { args ->
         val viewModel: PostEditorViewModel =
             injectViewModel(key = "edit-post-${args.id}") { newPostViewModel }
 
@@ -313,78 +252,72 @@ private fun NavGraphBuilder.tabGraph(
         }
 
         PostEditorComposable(
-            navController = navController, uris = null, viewModel = viewModel
+            navController = navigator, uris = null, viewModel = viewModel
         )
     }
 
-    composable<Destination.MutedAccounts> {
-        MutedAccountsComposable(navController)
+    entry<Destination.MutedAccounts> {
+        MutedAccountsComposable(navigator)
     }
 
-    composable<Destination.BlockedAccounts> {
-        BlockedAccountsComposable(navController)
+    entry<Destination.BlockedAccounts> {
+        BlockedAccountsComposable(navigator)
     }
 
-    composable<Destination.LikedPosts> {
-        LikedPostsComposable(navController)
+    entry<Destination.LikedPosts> {
+        LikedPostsComposable(navigator)
     }
 
-    composable<Destination.BookmarkedPosts> {
-        BookmarkedPostsComposable(navController)
+    entry<Destination.BookmarkedPosts> {
+        BookmarkedPostsComposable(navigator)
     }
 
-    composable<Destination.FollowedHashtags> {
-        FollowedHashtagsComposable(navController)
+    entry<Destination.FollowedHashtags> {
+        FollowedHashtagsComposable(navigator)
     }
 
-    composable<Destination.AboutInstance> {
-        AboutInstanceComposable(navController)
+    entry<Destination.AboutInstance> {
+        AboutInstanceComposable(navigator)
     }
 
-    composable<Destination.AboutPixelix> {
-        AboutPixelixComposable(navController)
+    entry<Destination.AboutPixelix> {
+        AboutPixelixComposable(navigator)
     }
 
-    composable<Destination.OwnProfile> {
-        OwnProfileComposable(navController, openPreferencesDrawer)
+    entry<Destination.OwnProfile> {
+        OwnProfileComposable(navigator, openPreferencesDrawer)
     }
 
-    composable<Destination.Followers> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Followers>()
+    entry<Destination.Followers> { args ->
         FollowersMainComposable(
-            navController,
+            navigator,
             accountId = args.userId,
             username = args.username,
             isFollowers = args.isFollowers
         )
     }
 
-    composable<Destination.Post> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Post>()
-        SinglePostComposable(navController, postId = args.id, args.refresh, args.openReplies)
+    entry<Destination.Post> { args ->
+        SinglePostComposable(navigator, postId = args.id, args.refresh, args.openReplies)
     }
 
-    composable<Destination.Collection> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Collection>()
-        CollectionComposable(navController, collectionId = args.id)
+    entry<Destination.Collection> { args ->
+        CollectionComposable(navigator, collectionId = args.id)
     }
 
-    composable<Destination.Search> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Search>()
-        ExploreComposable(navController, args.page)
+    entry<Destination.Search> { args ->
+        ExploreComposable(navigator, args.page)
     }
 
-    composable<Destination.Conversations> {
-        ConversationsComposable(navController = navController)
+    entry<Destination.Conversations> {
+        ConversationsComposable(navController = navigator)
     }
 
-    composable<Destination.Chat> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Chat>()
-        ChatComposable(navController = navController, accountId = args.id)
+    entry<Destination.Chat> { args ->
+        ChatComposable(navController = navigator, accountId = args.id)
     }
 
-    composable<Destination.Mention> { navBackStackEntry ->
-        val args = navBackStackEntry.toRoute<Destination.Mention>()
-        MentionComposable(navController = navController, mentionId = args.id)
+    entry<Destination.Mention> { args ->
+        MentionComposable(navController = navigator, mentionId = args.id)
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.Dialog
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.scene.DialogSceneStrategy
 import com.daniebeler.pfpixelix.EdgeToEdgeDialogProperties
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.HomeComposable
@@ -171,7 +172,9 @@ internal fun appEntryProvider(
         PostEditorComposable(navigator, imageUris)
     }
 
-    entry<Destination.NewLogin> {
+    entry<Destination.NewLogin>(
+        metadata = DialogSceneStrategy.dialog(EdgeToEdgeDialogProperties())
+    ) {
         LoginComposable(true, navigator)
     }
 

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
@@ -50,6 +50,7 @@ import com.daniebeler.pfpixelix.utils.KmpUri
 import com.daniebeler.pfpixelix.utils.toKmpUri
 import kotlinx.serialization.Serializable
 
+@Serializable
 sealed interface Destination : NavKey {
     @Serializable
     data class Hashtag(val hashtag: String) : Destination

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/navigation/Navigation.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
 import androidx.navigation.compose.navigation
 import androidx.navigation.toRoute
+import androidx.navigation3.runtime.NavKey
 import com.daniebeler.pfpixelix.EdgeToEdgeDialogProperties
 import com.daniebeler.pfpixelix.di.injectViewModel
 import com.daniebeler.pfpixelix.ui.composables.HomeComposable
@@ -49,7 +50,7 @@ import com.daniebeler.pfpixelix.utils.KmpUri
 import com.daniebeler.pfpixelix.utils.toKmpUri
 import kotlinx.serialization.Serializable
 
-sealed interface Destination {
+sealed interface Destination : NavKey {
     @Serializable
     data class Hashtag(val hashtag: String) : Destination
 

--- a/sharedUI/src/iosMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.ios.kt
@@ -2,6 +2,7 @@ package com.daniebeler.pfpixelix.domain.service.platform
 
 import androidx.compose.ui.platform.LocalUriHandler
 import co.touchlab.kermit.Logger
+import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.KmpUri
@@ -36,7 +37,11 @@ actual class Platform actual constructor(
         return platformFile.toKmpUri()
     }
 
-        actual fun openUrl(url: String) {
+    actual fun prepareAuthBrowser(host: String, backendType: BackendType): Boolean = true
+
+    actual suspend fun consumePreparedAuthData(): PreparedAuthData? = null
+
+    actual fun openUrl(url: String) {
         if (prefs.useInAppBrowser) {
             val safariViewController = SFSafariViewController(uRL = NSURL(string = url))
             dispatch_async(dispatch_get_main_queue()) {

--- a/sharedUI/src/jvmMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.jvm.kt
+++ b/sharedUI/src/jvmMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.jvm.kt
@@ -1,5 +1,6 @@
 package com.daniebeler.pfpixelix.domain.service.platform
 
+import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.KmpUri
@@ -14,6 +15,10 @@ actual class Platform actual constructor(
     private val context: KmpContext,
     private val prefs: UserPreferences
 ) {
+    actual fun prepareAuthBrowser(host: String, backendType: BackendType): Boolean = true
+
+    actual suspend fun consumePreparedAuthData(): PreparedAuthData? = null
+
     actual fun openUrl(url: String) {
         val os = System.getProperty("os.name").lowercase()
 

--- a/sharedUI/src/nonWebMain/kotlin/com/daniebeler/pfpixelix/BrowserIntegration.nonWeb.kt
+++ b/sharedUI/src/nonWebMain/kotlin/com/daniebeler/pfpixelix/BrowserIntegration.nonWeb.kt
@@ -1,0 +1,6 @@
+package com.daniebeler.pfpixelix
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun BrowserIntegration() = Unit

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
@@ -1,33 +1,9 @@
 package com.daniebeler.pfpixelix
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.navigation3.scene.SceneInfo
-import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import com.github.terrakok.navigation3.browser.HierarchicalBrowserNavigation
-import com.github.terrakok.navigation3.browser.buildBrowserHistoryFragment
 
-/**
- * Connects browser history to the same NavigationEventDispatcher that NavDisplay uses.
- * The integration deliberately derives the current URL from dispatcher history instead of
- * observing the app back stack directly, matching the Navigation 3 multiplatform recipes.
- */
 @Composable
 internal actual fun BrowserIntegration() {
-    val dispatcher = LocalNavigationEventDispatcherOwner.current?.navigationEventDispatcher ?: return
-    val history by dispatcher.history.collectAsState()
-
-    HierarchicalBrowserNavigation {
-        val index = history.currentIndex.takeIf { it >= 0 } ?: 0
-        history.mergedHistory.getOrNull(index)?.let { info ->
-            val key = if (info is SceneInfo<*>) {
-                info.scene.entries.lastOrNull()?.contentKey.toString()
-            } else {
-                info::class.simpleName
-            }
-            val name = key?.lowercase()?.replace(" ", "_").orEmpty()
-            buildBrowserHistoryFragment(name)
-        }
-    }
+    HierarchicalBrowserNavigation()
 }

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
@@ -1,0 +1,57 @@
+package com.daniebeler.pfpixelix
+
+import androidx.compose.runtime.Composable
+import com.daniebeler.pfpixelix.ui.navigation.Destination
+import com.github.terrakok.navigation3.browser.HierarchicalBrowserNavigation
+import com.github.terrakok.navigation3.browser.buildBrowserHistoryFragment
+
+@Composable
+internal fun PixelixBrowserNavigation(destination: Destination) {
+    HierarchicalBrowserNavigation {
+        destination.toBrowserHistoryFragment()
+    }
+}
+
+private fun Destination.toBrowserHistoryFragment(): String = when (this) {
+    is Destination.Post -> route("post", "id" to id)
+    is Destination.EditPost -> route("edit-post", "id" to id)
+    is Destination.Collection -> route("collection", "id" to id)
+    is Destination.Followers -> route(
+        "followers",
+        "userId" to userId,
+        "username" to username,
+        "followers" to isFollowers.toString(),
+    )
+    is Destination.Chat -> route("chat", "id" to id)
+    is Destination.Mention -> route("mention", "id" to id)
+    is Destination.Profile -> route("profile", "id" to userId, "username" to username)
+    is Destination.ProfileByUsername -> route("profile", "username" to userName)
+    is Destination.Hashtag -> route("hashtag", "tag" to hashtag)
+    is Destination.HashtagTimeline -> route("hashtag", "tag" to hashtag)
+    is Destination.CameraTimeline -> route("camera", "camera" to camera)
+    is Destination.CategoryTimeline -> route("category", "category" to category)
+    is Destination.LensTimeline -> route("lens", "lens" to lens)
+    is Destination.FilmTimeline -> route("film", "film" to film)
+    is Destination.Search -> route("search", "page" to page.toString())
+    is Destination.NewPost -> route("new-post")
+    Destination.FirstLogin -> route("login")
+    Destination.NewLogin -> route("new-login")
+    Destination.Feeds, Destination.HomeTabFeeds -> route("feeds")
+    Destination.Notifications, Destination.HomeTabNotifications -> route("notifications")
+    Destination.OwnProfile, Destination.HomeTabOwnProfile -> route("profile")
+    Destination.HomeTabSearch -> route("search")
+    Destination.HomeTabNewPost -> route("new-post")
+    Destination.Conversations -> route("messages")
+    Destination.EditProfile -> route("edit-profile")
+    Destination.IconSelection -> route("app-icon")
+    Destination.MutedAccounts -> route("muted-accounts")
+    Destination.BlockedAccounts -> route("blocked-accounts")
+    Destination.LikedPosts -> route("liked-posts")
+    Destination.BookmarkedPosts -> route("bookmarked-posts")
+    Destination.FollowedHashtags -> route("followed-hashtags")
+    Destination.AboutInstance -> route("about-instance")
+    Destination.AboutPixelix -> route("about-pixelix")
+}
+
+private fun route(name: String, vararg parameters: Pair<String, String?>): String =
+    buildBrowserHistoryFragment(name, parameters.toMap())

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/BrowserNavigation.kt
@@ -1,57 +1,33 @@
 package com.daniebeler.pfpixelix
 
 import androidx.compose.runtime.Composable
-import com.daniebeler.pfpixelix.ui.navigation.Destination
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.navigation3.scene.SceneInfo
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import com.github.terrakok.navigation3.browser.HierarchicalBrowserNavigation
 import com.github.terrakok.navigation3.browser.buildBrowserHistoryFragment
 
+/**
+ * Connects browser history to the same NavigationEventDispatcher that NavDisplay uses.
+ * The integration deliberately derives the current URL from dispatcher history instead of
+ * observing the app back stack directly, matching the Navigation 3 multiplatform recipes.
+ */
 @Composable
-internal fun PixelixBrowserNavigation(destination: Destination) {
+internal actual fun BrowserIntegration() {
+    val dispatcher = LocalNavigationEventDispatcherOwner.current?.navigationEventDispatcher ?: return
+    val history by dispatcher.history.collectAsState()
+
     HierarchicalBrowserNavigation {
-        destination.toBrowserHistoryFragment()
+        val index = history.currentIndex.takeIf { it >= 0 } ?: 0
+        history.mergedHistory.getOrNull(index)?.let { info ->
+            val key = if (info is SceneInfo<*>) {
+                info.scene.entries.lastOrNull()?.contentKey.toString()
+            } else {
+                info::class.simpleName
+            }
+            val name = key?.lowercase()?.replace(" ", "_").orEmpty()
+            buildBrowserHistoryFragment(name)
+        }
     }
 }
-
-private fun Destination.toBrowserHistoryFragment(): String = when (this) {
-    is Destination.Post -> route("post", "id" to id)
-    is Destination.EditPost -> route("edit-post", "id" to id)
-    is Destination.Collection -> route("collection", "id" to id)
-    is Destination.Followers -> route(
-        "followers",
-        "userId" to userId,
-        "username" to username,
-        "followers" to isFollowers.toString(),
-    )
-    is Destination.Chat -> route("chat", "id" to id)
-    is Destination.Mention -> route("mention", "id" to id)
-    is Destination.Profile -> route("profile", "id" to userId, "username" to username)
-    is Destination.ProfileByUsername -> route("profile", "username" to userName)
-    is Destination.Hashtag -> route("hashtag", "tag" to hashtag)
-    is Destination.HashtagTimeline -> route("hashtag", "tag" to hashtag)
-    is Destination.CameraTimeline -> route("camera", "camera" to camera)
-    is Destination.CategoryTimeline -> route("category", "category" to category)
-    is Destination.LensTimeline -> route("lens", "lens" to lens)
-    is Destination.FilmTimeline -> route("film", "film" to film)
-    is Destination.Search -> route("search", "page" to page.toString())
-    is Destination.NewPost -> route("new-post")
-    Destination.FirstLogin -> route("login")
-    Destination.NewLogin -> route("new-login")
-    Destination.Feeds, Destination.HomeTabFeeds -> route("feeds")
-    Destination.Notifications, Destination.HomeTabNotifications -> route("notifications")
-    Destination.OwnProfile, Destination.HomeTabOwnProfile -> route("profile")
-    Destination.HomeTabSearch -> route("search")
-    Destination.HomeTabNewPost -> route("new-post")
-    Destination.Conversations -> route("messages")
-    Destination.EditProfile -> route("edit-profile")
-    Destination.IconSelection -> route("app-icon")
-    Destination.MutedAccounts -> route("muted-accounts")
-    Destination.BlockedAccounts -> route("blocked-accounts")
-    Destination.LikedPosts -> route("liked-posts")
-    Destination.BookmarkedPosts -> route("bookmarked-posts")
-    Destination.FollowedHashtags -> route("followed-hashtags")
-    Destination.AboutInstance -> route("about-instance")
-    Destination.AboutPixelix -> route("about-pixelix")
-}
-
-private fun route(name: String, vararg parameters: Pair<String, String?>): String =
-    buildBrowserHistoryFragment(name, parameters.toMap())

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
@@ -29,7 +29,6 @@ fun webApp() {
     ComposeViewport {
         App(
             appComponent = appComponent,
-            browserNavigation = { PixelixBrowserNavigation(it) },
             exitApp = { /* browser Back leaves the app from its root */ },
         )
     }

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
@@ -25,6 +25,12 @@ fun webApp() {
     setOAuthRedirectCallback {
         appComponent.systemUrlHandler.onRedirect(it)
     }
+    setOAuthRedirectMessageListener {
+        appComponent.systemUrlHandler.onRedirect(it)
+    }
+    setOAuthRedirectBroadcastListener {
+        appComponent.systemUrlHandler.onRedirect(it)
+    }
 
     ComposeViewport {
         App(
@@ -37,3 +43,27 @@ fun webApp() {
 
 private fun setOAuthRedirectCallback(cb: (String) -> Unit): Unit =
     js("{ window.pixelixOAuthCallback = cb; }")
+
+private fun setOAuthRedirectMessageListener(cb: (String) -> Unit): Unit = js(
+    """{
+        window.addEventListener('message', function(event) {
+            if (event.origin !== window.location.origin) return;
+            if (!event.data || event.data.type !== 'pixelix-oauth-redirect') return;
+            cb(event.data.url);
+        });
+    }"""
+)
+
+private fun setOAuthRedirectBroadcastListener(cb: (String) -> Unit): Unit = js(
+    """{
+        if (typeof BroadcastChannel === 'undefined') return;
+        if (window.pixelixOAuthChannel) window.pixelixOAuthChannel.close();
+        var channel = new BroadcastChannel('pixelix-oauth');
+        channel.onmessage = function(event) {
+            if (!event.data || event.data.type !== 'pixelix-oauth-redirect') return;
+            cb(event.data.url);
+        };
+        // Keep the channel alive for the lifetime of the PWA page.
+        window.pixelixOAuthChannel = channel;
+    }"""
+)

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/WebApp.kt
@@ -2,8 +2,6 @@ package com.daniebeler.pfpixelix
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
-import androidx.navigation.ExperimentalBrowserHistoryApi
-import androidx.navigation.bindToBrowserNavigation
 import coil3.SingletonImageLoader
 import com.daniebeler.pfpixelix.di.AppComponent
 import com.daniebeler.pfpixelix.di.create
@@ -11,7 +9,7 @@ import com.daniebeler.pfpixelix.domain.service.icon.WebAppIconManager
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.configureLogger
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalBrowserHistoryApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 fun webApp() {
     val appComponent = AppComponent.create(
         object : KmpContext() {},
@@ -31,26 +29,12 @@ fun webApp() {
     ComposeViewport {
         App(
             appComponent = appComponent,
-            onNavHostReady = { navController ->
-                // `App` recreates the NavController via `key(activeUser)` on every login/logout.
-                // `bindToBrowserNavigation` restores the current URL fragment onto the controller it
-                // binds, so a freshly-created controller would immediately navigate back to the
-                // previous session's route (e.g. bounce to FirstLogin right after a successful
-                // login), overriding the new NavHost's startDestination. Drop the stale fragment
-                // first so the new controller honors its startDestination.
-                // Trade-off: this also clears a deep-link fragment on cold start; acceptable until
-                // deep linking is wired up on web.
-                clearBrowserRoute()
-                navController.bindToBrowserNavigation()
-            },
-            exitApp = { /* no-op: the browser tab has no explicit exit */ }
+            browserNavigation = { PixelixBrowserNavigation(it) },
+            exitApp = { /* browser Back leaves the app from its root */ },
         )
     }
 }
 
-/** Removes the `#route` fragment from the address bar without adding a history entry. */
-private fun clearBrowserRoute(): Unit =
-    js("{ window.history.replaceState(null, '', window.location.pathname + window.location.search); }")
 
 private fun setOAuthRedirectCallback(cb: (String) -> Unit): Unit =
     js("{ window.pixelixOAuthCallback = cb; }")

--- a/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.web.kt
+++ b/sharedUI/src/webMain/kotlin/com/daniebeler/pfpixelix/domain/service/platform/Platform.web.kt
@@ -1,10 +1,12 @@
 package com.daniebeler.pfpixelix.domain.service.platform
 
+import com.daniebeler.pfpixelix.domain.service.general.BackendType
 import com.daniebeler.pfpixelix.domain.service.preferences.UserPreferences
 import com.daniebeler.pfpixelix.utils.KmpContext
 import com.daniebeler.pfpixelix.utils.KmpUri
 import com.daniebeler.pfpixelix.utils.toKmpUri
 import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.delay
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -12,11 +14,28 @@ actual class Platform actual constructor(
     private val context: KmpContext,
     private val prefs: UserPreferences
 ) {
-    // Handle to the OAuth popup opened by [openUrl], so [dismissBrowser] can close it once the
-    // redirect has been received. The popup normally closes itself (see oauth-callback.html).
+    // Kept so the app can close the OAuth tab after receiving the callback.
     private var authPopup: JsAny? = null
 
     actual fun toSafeUri(platformFile: PlatformFile): KmpUri = platformFile.toKmpUri()
+
+    actual fun prepareAuthBrowser(host: String, backendType: BackendType): Boolean {
+        clearPreparedAuthData()
+        val launcherUrl = buildLauncherUrl(host, backendType.name.lowercase(), redirectUrl)
+        authPopup = openInNewTab(launcherUrl)
+        return authPopup != null && !isWindowClosed(authPopup)
+    }
+
+    actual suspend fun consumePreparedAuthData(): PreparedAuthData? {
+        repeat(AUTH_PREPARATION_ATTEMPTS) {
+            takePreparedAuthData()?.let {
+                clearPreparedAuthData()
+                return it
+            }
+            delay(AUTH_PREPARATION_POLL_MS)
+        }
+        error("Timed out while preparing the OAuth login page")
+    }
 
     actual fun openUrl(url: String) {
         authPopup = openInNewTab(url)
@@ -34,7 +53,39 @@ actual class Platform actual constructor(
     actual fun pinWidget() {}
 }
 
+private fun buildLauncherUrl(host: String, backendType: String, redirectUrl: String): String = js(
+    """{
+        var params = new URLSearchParams({
+            host: host,
+            backend: backendType,
+            redirect_uri: redirectUrl
+        });
+        return window.location.origin + '/oauth-launcher.html?' + params.toString();
+    }"""
+)
+
 private fun openInNewTab(url: String): JsAny? = js("window.open(url, '_blank')")
+
+private fun isWindowClosed(win: JsAny?): Boolean =
+    js("win == null || win.closed")
+
+private fun clearPreparedAuthData(): Unit = js(
+    """{
+        window.localStorage.removeItem('pixelix-oauth-client-id');
+        window.localStorage.removeItem('pixelix-oauth-client-secret');
+    }"""
+)
+
+private fun takePreparedAuthData(): PreparedAuthData? {
+    val clientId = readLocalStorage("pixelix-oauth-client-id") ?: return null
+    return PreparedAuthData(clientId, readLocalStorage("pixelix-oauth-client-secret"))
+}
+
+private fun readLocalStorage(key: String): String? =
+    js("window.localStorage.getItem(key)")
+
+private const val AUTH_PREPARATION_ATTEMPTS = 120
+private const val AUTH_PREPARATION_POLL_MS = 250L
 
 // The OAuth authorize page opens in a popup; the callback page posts the redirect URL back to
 // this window (wired up in createWebAppComponent) and the coroutine in the main tab resumes.

--- a/webApp/src/commonMain/resources/oauth-callback.html
+++ b/webApp/src/commonMain/resources/oauth-callback.html
@@ -7,17 +7,39 @@
     <body>
         <p>You can close this window.</p>
         <script>
-            // OAuth redirect target. The Pixelix tab that started the login flow is waiting for the
-            // auth code; hand the full redirect URL (with ?code=...) back to it and close ourselves.
-            // The opener is same-origin, so we call the callback it installed on `window`.
+            // Return the redirect to the Pixelix window. A direct same-origin callback is fastest;
+            // postMessage is retained as a fallback for installed PWAs/mobile browser contexts.
             (function () {
+                var delivered = false;
+                var message = { type: 'pixelix-oauth-redirect', url: window.location.href };
                 try {
-                    if (window.opener && !window.opener.closed &&
-                        typeof window.opener.pixelixOAuthCallback === 'function') {
-                        window.opener.pixelixOAuthCallback(window.location.href);
+                    if (window.opener && !window.opener.closed) {
+                        if (typeof window.opener.pixelixOAuthCallback === 'function') {
+                            window.opener.pixelixOAuthCallback(window.location.href);
+                        } else {
+                            window.opener.postMessage(message, window.location.origin);
+                        }
+                        delivered = true;
                     }
-                } catch (e) { /* opener gone or cross-origin: nothing we can do */ }
-                window.close();
+                } catch (e) { /* opener unavailable or isolated */ }
+
+                // Standalone PWAs may open OAuth in a browser context without window.opener.
+                // BroadcastChannel still reaches the original same-origin PWA window.
+                try {
+                    if (typeof BroadcastChannel !== 'undefined') {
+                        var channel = new BroadcastChannel('pixelix-oauth');
+                        channel.postMessage(message);
+                        channel.close();
+                        delivered = true;
+                    }
+                } catch (e) { /* BroadcastChannel unavailable */ }
+
+                if (delivered) {
+                    window.close();
+                } else {
+                    document.querySelector('p').textContent =
+                        'Return to Pixelix to finish signing in.';
+                }
             })();
         </script>
     </body>

--- a/webApp/src/commonMain/resources/oauth-launcher.html
+++ b/webApp/src/commonMain/resources/oauth-launcher.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Opening sign in…</title>
+    </head>
+    <body>
+        <p id="status">Preparing sign in…</p>
+        <script>
+            const CLIENT_ID_KEY = 'pixelix-oauth-client-id';
+            const CLIENT_SECRET_KEY = 'pixelix-oauth-client-secret';
+
+            function addRepeated(body, name, values) {
+                values.forEach(value => body.append(name, value));
+            }
+
+            function createRegistration(server, backend, redirectUri) {
+                if (backend !== 'vernissage') {
+                    const url = new URL('/api/v1/apps', server);
+                    url.searchParams.set('client_name', 'pixelix');
+                    url.searchParams.set('redirect_uris', redirectUri);
+                    return { url, options: { method: 'POST' } };
+                }
+
+                const body = new URLSearchParams();
+                body.set('client_name', 'Pixelix');
+                body.set('redirect_uris', redirectUri);
+                addRepeated(body, 'grant_types', ['authorization_code', 'refresh_token']);
+                addRepeated(body, 'response_types', ['code']);
+                return {
+                    url: new URL('/api/v1/auth-dynamic-clients', server),
+                    options: {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+                        body: body.toString()
+                    }
+                };
+            }
+
+            function createAuthorizeUrl(server, backend, redirectUri, clientId) {
+                const path = backend === 'vernissage'
+                    ? '/api/v1/oauth/authorize'
+                    : '/oauth/authorize';
+                const url = new URL(path, server);
+                url.searchParams.set('response_type', 'code');
+                url.searchParams.set('client_id', clientId);
+                url.searchParams.set('redirect_uri', redirectUri);
+
+                if (backend === 'vernissage') {
+                    const randomId = () => String(Math.floor(100000 + Math.random() * 900000));
+                    url.searchParams.set('scope', 'read write');
+                    url.searchParams.set('state', randomId());
+                    url.searchParams.set('nonce', randomId());
+                }
+                return url;
+            }
+
+            (async function startOAuth() {
+                const status = document.getElementById('status');
+                try {
+                    const params = new URLSearchParams(window.location.search);
+                    const host = params.get('host');
+                    const backend = params.get('backend');
+                    const redirectUri = params.get('redirect_uri');
+                    if (!host || !backend || !redirectUri) throw new Error('Missing OAuth parameters');
+
+                    const server = new URL('https://' + host.replace(/^https?:\/\//, ''));
+                    const registration = createRegistration(server, backend, redirectUri);
+                    const response = await fetch(registration.url, registration.options);
+                    if (!response.ok) throw new Error('OAuth registration failed: HTTP ' + response.status);
+
+                    const authData = await response.json();
+                    if (!authData.client_id) throw new Error('OAuth registration returned no client_id');
+
+                    // The app needs these values after the OAuth callback to exchange the code.
+                    if (authData.client_secret) {
+                        localStorage.setItem(CLIENT_SECRET_KEY, authData.client_secret);
+                    }
+                    // Store the ID last: the app treats it as the "preparation complete" marker.
+                    localStorage.setItem(CLIENT_ID_KEY, authData.client_id);
+
+                    const authorizeUrl = createAuthorizeUrl(
+                        server,
+                        backend,
+                        redirectUri,
+                        authData.client_id
+                    );
+                    window.location.replace(authorizeUrl);
+                } catch (error) {
+                    status.textContent = 'Could not start sign in: ' +
+                        (error?.message || String(error));
+                }
+            })();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This PR introduces a significant navigation migration and refactoring, replacing the deprecated Navigation 2 implementation with Navigation 3 across the project.

The change affects core application behavior, including:
 - Navigation state and back-stack management
 - Multiple top-level back stacks
 - Screen and dialog destinations
 - ViewModel scoping and navigation side effects
 - Browser history integration
 - Navigation APIs used throughout the UI

Because navigation is a foundational part of the application, this PR requires careful review and thorough testing, particularly around login/logout, account switching, tab navigation, back behavior, and browser history.

Although the scope is substantial, Navigation 2 is now outdated, and moving to Navigation 3 is necessary to keep the project aligned with the current Compose navigation architecture and future platform support.